### PR TITLE
fix bug in 'remove last slash'

### DIFF
--- a/lua/venv-selector/utils.lua
+++ b/lua/venv-selector/utils.lua
@@ -17,6 +17,7 @@ utils.remove_last_slash = function(s)
 	if string.sub(s, -1, -1) == separator then
 		return string.sub(s, 1, -2)
 	end
+  return s
 end
 
 return utils


### PR DESCRIPTION
Hello! When running the plugin in ubuntu, got an exception:
Error executing luv callback:
.../nvim/lazy/venv-selector.nvim/lua/venv-selector/init.lua:80: wrong number of arguments to 'insert'
stack trace:
 `
 [C]: in function 'insert'
         .../nvim/lazy/venv-selector.nvim/lua/venv-selector/init.lua:80: in function <.../nvim/lazy/venv-selector.nvim/lua/venv-selector/init .lua:69>
`
Although in arch linux everything worked well.
After some digging, I found a small bug.
P.s. thanks for the cool plugin, it is very useful in my work!