### PR TITLE
feat: use vim.notify to update activated venv

### DIFF
--- a/lua/venv-selector/venv.lua
+++ b/lua/venv-selector/venv.lua
@@ -7,8 +7,8 @@ local config = require("venv-selector.config")
 
 local M = {
 	current_python_path = nil, -- Contains path to current python if activated, nil otherwise
-	current_venv = nil, -- Contains path to current venv folder if activated, nil otherwise
-	current_bin_path = nil, -- Keeps track of old system path so we can remove it when adding a new one
+	current_venv = nil,       -- Contains path to current venv folder if activated, nil otherwise
+	current_bin_path = nil,   -- Keeps track of old system path so we can remove it when adding a new one
 	fd_handle = nil,
 	path_to_search = nil,
 	buffer_dir = nil,
@@ -88,7 +88,7 @@ M.set_venv_and_system_paths = function(venv_row)
 	local venv_python = new_bin_path .. sys.path_sep .. sys.python_name
 
 	M.set_pythonpath(venv_python)
-	vim.notify("VenvSelect: Activated '" .. venv_python .. "'.", vim.log.levels.INFO, { title = "VenvManager" })
+	vim.notify("VenvSelect: Activated '" .. venv_python .. "'.", vim.log.levels.INFO, { title = "VenvSelect" })
 
 	local current_system_path = vim.fn.getenv("PATH")
 	local prev_bin_path = M.current_bin_path
@@ -188,10 +188,10 @@ M.find_workspace_venvs = function()
 	if search_path_string:len() ~= 0 then
 		local search_path_regexp = utils.create_fd_venv_names_regexp(config.settings.name)
 		local cmd = config.settings.fd_binary_name
-			.. " -HItd --absolute-path --color never '"
-			.. search_path_regexp
-			.. "' "
-			.. search_path_string
+				.. " -HItd --absolute-path --color never '"
+				.. search_path_regexp
+				.. "' "
+				.. search_path_string
 
 		dbg("Running search for workspace venvs with: " .. cmd)
 		local openPop = assert(io.popen(cmd, "r"))
@@ -208,8 +208,8 @@ M.find_venv_manager_venvs = function()
 	local search_path_string = utils.create_fd_search_path_string(paths)
 	if search_path_string:len() ~= 0 then
 		local cmd = config.settings.fd_binary_name
-			.. " . -HItd --absolute-path --max-depth 1 --color never "
-			.. search_path_string
+				.. " . -HItd --absolute-path --max-depth 1 --color never "
+				.. search_path_string
 		dbg("Running search for venv manager venvs with: " .. cmd)
 		local openPop = assert(io.popen(cmd, "r"))
 		telescope.add_lines(openPop:lines(), "VenvManager")

--- a/lua/venv-selector/venv.lua
+++ b/lua/venv-selector/venv.lua
@@ -88,7 +88,7 @@ M.set_venv_and_system_paths = function(venv_row)
 	local venv_python = new_bin_path .. sys.path_sep .. sys.python_name
 
 	M.set_pythonpath(venv_python)
-	print("VenvSelect: Activated '" .. venv_python .. "'.")
+	vim.notify("VenvSelect: Activated '" .. venv_python .. "'.", vim.log.levels.INFO, { title = "VenvManager" })
 
 	local current_system_path = vim.fn.getenv("PATH")
 	local prev_bin_path = M.current_bin_path


### PR DESCRIPTION
Instead of using `print()` changed to use `vim.notify()` for better user experience.