### PR TITLE
fix cache paths for macOS

### DIFF
--- a/lua/venv-selector/system.lua
+++ b/lua/venv-selector/system.lua
@@ -46,8 +46,7 @@ M.get_cache_default_path = function()
 	if M.sysname == "Windows_NT" then
 		return "%APPDATA%\\venv-selector\\"
 	end
-	local user = vim.fn.getenv("USER")
-	return "/home/" .. user .. "/.cache/venv-selector/"
+	return "~/.cache/venv-selector/"
 end
 
 M.get_info = function()

--- a/lua/venv-selector/system.lua
+++ b/lua/venv-selector/system.lua
@@ -46,7 +46,11 @@ M.get_cache_default_path = function()
 	if M.sysname == "Windows_NT" then
 		return "%APPDATA%\\venv-selector\\"
 	end
-	return "~/.cache/venv-selector/"
+	local user = vim.fn.getenv("USER")
+	if M.sysname == "Darwin" then
+		return "/Users/" .. user .. "/.cache/venv-selector/"
+	end
+	return "/home/" .. user .. "/.cache/venv-selector/"
 end
 
 M.get_info = function()


### PR DESCRIPTION
since this last update with the caching i can't start venvs because i get this error:
![image](https://user-images.githubusercontent.com/44374535/233017881-2cc03a24-2897-4f43-b031-9509eb72b085.png)


the path for mac should be `/Users/<username>/` instead of `/home/<username>/`.
i tried to do it with `~/.cache` which will look nicer and work for both mac and linux, but i got errors from,`writefile` function.
so i just put the full path for mac.

maybe adding an option to not cache at all is a great option if paths are not standard and i just dont want to get these errors?
even if not loading from cache, it still tries to write the cache which can cause bugs.
