### PR TITLE
feat: Add pyenv-virtualenv support

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Currently provided hooks are:
 
 The selected virtual environment and path to the python executable is available from these two functions:
 
-```
+```lua
 require("venv-selector").get_active_path() -- Gives path to the python executable inside the activated virtual environment
 require("venv-selector").get_active_venv() -- Gives path to the activated virtual environment folder
 require("venv-selector").retrieve_from_cache() -- To activate the last virtual environment set in the current working directory
@@ -278,33 +278,37 @@ once = true,
 })
 ```
 
-### If you use Poetry or Pipenv
+### If you use Poetry, Pipenv or Pyenv-virtualenv
 
-If you use Poetry or Pipenv, you typically have all the virtual environments located in the same path as subfolders.
+If you use Poetry, Pipenv or Pyenv-virtualenv, you typically have all the virtual environments located in the same path as subfolders.
 
-VenvSelector automatically looks in the default paths for both Poetry and Pipenv virtual environments:
+VenvSelector automatically looks in the default paths for both Poetry, Pipenv and Pyenv-virtualenv virtual environments:
 
 _Mac:_
 
 - Poetry: `$HOME/Library/Caches/pypoetry/virtualenvs`
 - Pipenv: `$HOME/.local/share/virtualenvs`
+- Pyenv: `HOME/.pyenv.versions`
 
 _Linux:_
 
 - Poetry: `$HOME/.cache/pypoetry/virtualenvs`
 - Pipenv: `$HOME/.local/share/virtualenvs`
+- Pyenv: `HOME/.pyenv.versions`
 
 _Windows:_
 
 - Poetry: `%APPDATA%\\pypoetry\\virtualenvs`
 - Pipenv: `$HOME\\virtualenvs`
+- Pyenv: `%USERPROFILE%\\.pyenv\\versions`
 
 You can override the default paths if the virtual environments are not being found by `VenvSelector`:
 
-```
+```lua
 require("venv-selector").setup({
 	poetry_path = "your_path_here",
-	pipenv_path = "your_path_here"
+	pipenv_path = "your_path_here",
+    pyenv_path = "your_path_here",
 })
 ```
 
@@ -336,7 +340,7 @@ You can see that the path shows that the virtual environments are located under 
 
 Copy the virtualenv path and set it as a parameter to the `VenvSelector` setup function:
 
-```
+```lua
 require("venv-selector").setup({
 	poetry_path = "/home/cado/.cache/pypoetry/virtualenvs",
 })
@@ -355,9 +359,25 @@ You can see that the path shows that the virtual environments are located under 
 
 Copy the virtualenv path and set it as a parameter to the `VenvSelector` setup function:
 
-```
+```lua
 require("venv-selector").setup({
 	pipenv_path = "/home/cado/.local/share/virtualenvs",
+})
+```
+
+#### Pyenv-virtualenv
+
+First run `pyenv root` to get the rootfolder for pyenv versions and shims are kept. You should get some output similar to this:
+
+`/home/cado/.pyenv`
+
+The virtualenvs are stored under the `versions` folder inside that directory. In this case it would be `/home/cado/.pyenv/versions`.
+
+Copy the virtualenv path and set it as a parameter to the `VenvSelector` setup function:
+
+```lua
+require("venv-selector").setup({
+    pyenv_path = "/home/cado/.pyenv/versions",
 })
 ```
 

--- a/lua/venv-selector/config.lua
+++ b/lua/venv-selector/config.lua
@@ -14,6 +14,7 @@ config.default_settings = {
 	parents = 2, -- When search is true, go this many directories up from the current opened buffer
 	poetry_path = system.get_venv_manager_default_path("Poetry"),
 	pipenv_path = system.get_venv_manager_default_path("Pipenv"),
+  pyenv_path = system.get_venv_manager_default_path("Pyenv"),
 	enable_debug_output = false,
 	auto_refresh = false, -- Uses cached results from last search
 	fd_binary_name = "fd",

--- a/lua/venv-selector/config.lua
+++ b/lua/venv-selector/config.lua
@@ -7,21 +7,21 @@ config = {
 
 -- Default settings if user is not setting anything in setup() call
 config.default_settings = {
-    search = true,
-    name = "venv",
-    search_workspace = true,
-    search_venv_managers = true,
-    parents = 2, -- When search is true, go this many directories up from the current opened buffer
-    poetry_path = system.get_venv_manager_default_path("Poetry"),
-    pipenv_path = system.get_venv_manager_default_path("Pipenv"),
-    pyenv_path = system.get_venv_manager_default_path("Pyenv"),
-    enable_debug_output = false,
-    auto_refresh = false, -- Uses cached results from last search
-    fd_binary_name = "fd",
-    cache_file = system.get_cache_default_path() .. "venvs.json",
-    cache_dir = system.get_cache_default_path(),
-    dap_enabled = false,
-    changed_venv_hooks = { hooks.pyright_hook, hooks.pylsp_hook },
+	search = true,
+	name = "venv",
+	search_workspace = true,
+	search_venv_managers = true,
+	parents = 2, -- When search is true, go this many directories up from the current opened buffer
+	poetry_path = system.get_venv_manager_default_path("Poetry"),
+	pipenv_path = system.get_venv_manager_default_path("Pipenv"),
+  pyenv_path = system.get_venv_manager_default_path("Pyenv"),
+	enable_debug_output = false,
+	auto_refresh = false, -- Uses cached results from last search
+	fd_binary_name = "fd",
+	cache_file = system.get_cache_default_path() .. "venvs.json",
+	cache_dir = system.get_cache_default_path(),
+	dap_enabled = false,
+	changed_venv_hooks = { hooks.pyright_hook, hooks.pylsp_hook },
 }
 
 -- Gets the search path supplied by the user in the setup function, or use current open buffer directory.

--- a/lua/venv-selector/config.lua
+++ b/lua/venv-selector/config.lua
@@ -7,21 +7,21 @@ config = {
 
 -- Default settings if user is not setting anything in setup() call
 config.default_settings = {
-	search = true,
-	name = "venv",
-	search_workspace = true,
-	search_venv_managers = true,
-	parents = 2, -- When search is true, go this many directories up from the current opened buffer
-	poetry_path = system.get_venv_manager_default_path("Poetry"),
-	pipenv_path = system.get_venv_manager_default_path("Pipenv"),
-  pyenv_path = system.get_venv_manager_default_path("Pyenv"),
-	enable_debug_output = false,
-	auto_refresh = false, -- Uses cached results from last search
-	fd_binary_name = "fd",
-	cache_file = system.get_cache_default_path() .. "venvs.json",
-	cache_dir = system.get_cache_default_path(),
-	dap_enabled = false,
-	changed_venv_hooks = { hooks.pyright_hook, hooks.pylsp_hook },
+    search = true,
+    name = "venv",
+    search_workspace = true,
+    search_venv_managers = true,
+    parents = 2, -- When search is true, go this many directories up from the current opened buffer
+    poetry_path = system.get_venv_manager_default_path("Poetry"),
+    pipenv_path = system.get_venv_manager_default_path("Pipenv"),
+    pyenv_path = system.get_venv_manager_default_path("Pyenv"),
+    enable_debug_output = false,
+    auto_refresh = false, -- Uses cached results from last search
+    fd_binary_name = "fd",
+    cache_file = system.get_cache_default_path() .. "venvs.json",
+    cache_dir = system.get_cache_default_path(),
+    dap_enabled = false,
+    changed_venv_hooks = { hooks.pyright_hook, hooks.pylsp_hook },
 }
 
 -- Gets the search path supplied by the user in the setup function, or use current open buffer directory.

--- a/lua/venv-selector/config.lua
+++ b/lua/venv-selector/config.lua
@@ -7,21 +7,21 @@ config = {
 
 -- Default settings if user is not setting anything in setup() call
 config.default_settings = {
-        search = true,
-        name = "venv",
-        search_workspace = true,
-        search_venv_managers = true,
-        parents = 2, -- When search is true, go this many directories up from the current opened buffer
-        poetry_path = system.get_venv_manager_default_path("Poetry"),
-        pipenv_path = system.get_venv_manager_default_path("Pipenv"),
-        pyenv_path = system.get_venv_manager_default_path("Pyenv"),
-        enable_debug_output = false,
-        auto_refresh = false, -- Uses cached results from last search
-        fd_binary_name = "fd",
-        cache_file = system.get_cache_default_path() .. "venvs.json",
-        cache_dir = system.get_cache_default_path(),
-        dap_enabled = false,
-        changed_venv_hooks = { hooks.pyright_hook, hooks.pylsp_hook },
+    search = true,
+    name = "venv",
+    search_workspace = true,
+    search_venv_managers = true,
+    parents = 2, -- When search is true, go this many directories up from the current opened buffer
+    poetry_path = system.get_venv_manager_default_path("Poetry"),
+    pipenv_path = system.get_venv_manager_default_path("Pipenv"),
+    pyenv_path = system.get_venv_manager_default_path("Pyenv"),
+    enable_debug_output = false,
+    auto_refresh = false, -- Uses cached results from last search
+    fd_binary_name = "fd",
+    cache_file = system.get_cache_default_path() .. "venvs.json",
+    cache_dir = system.get_cache_default_path(),
+    dap_enabled = false,
+    changed_venv_hooks = { hooks.pyright_hook, hooks.pylsp_hook },
 }
 
 -- Gets the search path supplied by the user in the setup function, or use current open buffer directory.

--- a/lua/venv-selector/config.lua
+++ b/lua/venv-selector/config.lua
@@ -7,21 +7,21 @@ config = {
 
 -- Default settings if user is not setting anything in setup() call
 config.default_settings = {
-    search = true,
-    name = "venv",
-    search_workspace = true,
-    search_venv_managers = true,
-    parents = 2, -- When search is true, go this many directories up from the current opened buffer
-    poetry_path = system.get_venv_manager_default_path("Poetry"),
-    pipenv_path = system.get_venv_manager_default_path("Pipenv"),
-    pyenv_path = system.get_venv_manager_default_path("Pyenv"),
-    enable_debug_output = false,
-    auto_refresh = false, -- Uses cached results from last search
-    fd_binary_name = "fd",
-    cache_file = system.get_cache_default_path() .. "venvs.json",
-    cache_dir = system.get_cache_default_path(),
-    dap_enabled = false,
-    changed_venv_hooks = { hooks.pyright_hook, hooks.pylsp_hook },
+        search = true,
+        name = "venv",
+        search_workspace = true,
+        search_venv_managers = true,
+        parents = 2, -- When search is true, go this many directories up from the current opened buffer
+        poetry_path = system.get_venv_manager_default_path("Poetry"),
+        pipenv_path = system.get_venv_manager_default_path("Pipenv"),
+        pyenv_path = system.get_venv_manager_default_path("Pyenv"),
+        enable_debug_output = false,
+        auto_refresh = false, -- Uses cached results from last search
+        fd_binary_name = "fd",
+        cache_file = system.get_cache_default_path() .. "venvs.json",
+        cache_dir = system.get_cache_default_path(),
+        dap_enabled = false,
+        changed_venv_hooks = { hooks.pyright_hook, hooks.pylsp_hook },
 }
 
 -- Gets the search path supplied by the user in the setup function, or use current open buffer directory.

--- a/lua/venv-selector/system.lua
+++ b/lua/venv-selector/system.lua
@@ -1,19 +1,19 @@
 local M = {
 	sysname = vim.loop.os_uname().sysname,
 	venv_manager_default_paths = {
-          Poetry = {
-                Linux = "~/.cache/pypoetry/virtualenvs",
-                Darwin = "~/Library/Caches/pypoetry/virtualenvs",
-                Windows_NT = "%APPDATA%\\pypoetry\\virtualenvs",
-          },
-          Pipenv = {
-                Linux = "~/.local/share/virtualenvs",
-                Darwin = "~/.local/share/virtualenvs",
-                Windows_NT = "~\\virtualenvs",
-          },
-          Pyenv = {
-                  Linux = "~/.pyenv/versions",
-          }
+      Poetry = {
+        Linux = "~/.cache/pypoetry/virtualenvs",
+        Darwin = "~/Library/Caches/pypoetry/virtualenvs",
+        Windows_NT = "%APPDATA%\\pypoetry\\virtualenvs",
+      },
+      Pipenv = {
+        Linux = "~/.local/share/virtualenvs",
+        Darwin = "~/.local/share/virtualenvs",
+        Windows_NT = "~\\virtualenvs",
+      },
+      Pyenv = {
+          Linux = "~/.pyenv/versions",
+      }
 	},
 }
 

--- a/lua/venv-selector/system.lua
+++ b/lua/venv-selector/system.lua
@@ -13,6 +13,8 @@ local M = {
 		},
     Pyenv = {
       Linux = "~/.pyenv/versions",
+      Darwin = "~/.pyenv/versions",
+      Windows = "%USERPROFILE%\\.pyenv\\versions",
     }
 	},
 }

--- a/lua/venv-selector/system.lua
+++ b/lua/venv-selector/system.lua
@@ -1,19 +1,19 @@
 local M = {
 	sysname = vim.loop.os_uname().sysname,
 	venv_manager_default_paths = {
-      Poetry = {
-        Linux = "~/.cache/pypoetry/virtualenvs",
-        Darwin = "~/Library/Caches/pypoetry/virtualenvs",
-        Windows_NT = "%APPDATA%\\pypoetry\\virtualenvs",
-      },
-      Pipenv = {
-        Linux = "~/.local/share/virtualenvs",
-        Darwin = "~/.local/share/virtualenvs",
-        Windows_NT = "~\\virtualenvs",
-      },
-      Pyenv = {
-          Linux = "~/.pyenv/versions",
-      }
+          Poetry = {
+                Linux = "~/.cache/pypoetry/virtualenvs",
+                Darwin = "~/Library/Caches/pypoetry/virtualenvs",
+                Windows_NT = "%APPDATA%\\pypoetry\\virtualenvs",
+          },
+          Pipenv = {
+                Linux = "~/.local/share/virtualenvs",
+                Darwin = "~/.local/share/virtualenvs",
+                Windows_NT = "~\\virtualenvs",
+          },
+          Pyenv = {
+                  Linux = "~/.pyenv/versions",
+          }
 	},
 }
 

--- a/lua/venv-selector/system.lua
+++ b/lua/venv-selector/system.lua
@@ -1,19 +1,19 @@
 local M = {
 	sysname = vim.loop.os_uname().sysname,
 	venv_manager_default_paths = {
-      Poetry = {
-        Linux = "~/.cache/pypoetry/virtualenvs",
-        Darwin = "~/Library/Caches/pypoetry/virtualenvs",
-        Windows_NT = "%APPDATA%\\pypoetry\\virtualenvs",
-      },
-      Pipenv = {
-        Linux = "~/.local/share/virtualenvs",
-        Darwin = "~/.local/share/virtualenvs",
-        Windows_NT = "~\\virtualenvs",
-      },
-      Pyenv = {
-          Linux = "~/.pyenv/versions",
-      }
+		Poetry = {
+			Linux = "~/.cache/pypoetry/virtualenvs",
+			Darwin = "~/Library/Caches/pypoetry/virtualenvs",
+			Windows_NT = "%APPDATA%\\pypoetry\\virtualenvs",
+		},
+		Pipenv = {
+			Linux = "~/.local/share/virtualenvs",
+			Darwin = "~/.local/share/virtualenvs",
+			Windows_NT = "~\\virtualenvs",
+		},
+    Pyenv = {
+      Linux = "~/.pyenv/versions",
+    }
 	},
 }
 

--- a/lua/venv-selector/system.lua
+++ b/lua/venv-selector/system.lua
@@ -1,19 +1,19 @@
 local M = {
 	sysname = vim.loop.os_uname().sysname,
 	venv_manager_default_paths = {
-		Poetry = {
-			Linux = "~/.cache/pypoetry/virtualenvs",
-			Darwin = "~/Library/Caches/pypoetry/virtualenvs",
-			Windows_NT = "%APPDATA%\\pypoetry\\virtualenvs",
-		},
-		Pipenv = {
-			Linux = "~/.local/share/virtualenvs",
-			Darwin = "~/.local/share/virtualenvs",
-			Windows_NT = "~\\virtualenvs",
-		},
-    Pyenv = {
-      Linux = "~/.pyenv/versions",
-    }
+      Poetry = {
+        Linux = "~/.cache/pypoetry/virtualenvs",
+        Darwin = "~/Library/Caches/pypoetry/virtualenvs",
+        Windows_NT = "%APPDATA%\\pypoetry\\virtualenvs",
+      },
+      Pipenv = {
+        Linux = "~/.local/share/virtualenvs",
+        Darwin = "~/.local/share/virtualenvs",
+        Windows_NT = "~\\virtualenvs",
+      },
+      Pyenv = {
+          Linux = "~/.pyenv/versions",
+      }
 	},
 }
 

--- a/lua/venv-selector/system.lua
+++ b/lua/venv-selector/system.lua
@@ -11,6 +11,9 @@ local M = {
 			Darwin = "~/.local/share/virtualenvs",
 			Windows_NT = "~\\virtualenvs",
 		},
+    Pyenv = {
+      Linux = "~/.pyenv/versions",
+    }
 	},
 }
 

--- a/lua/venv-selector/venv.lua
+++ b/lua/venv-selector/venv.lua
@@ -235,7 +235,7 @@ M.find_venv_manager_venvs = function()
         local search_path_string = utils.create_fd_search_path_string(paths)
         if search_path_string:len() ~= 0 then
                 local cmd = config.settings.fd_binary_name
-                        .. " . -HItd --absolute-path --max-depth 1 --color never "
+                        .. " . -HItd -tl --absolute-path --max-depth 1 --color never "
                         .. search_path_string
                 dbg("Running search for venv manager venvs with: " .. cmd)
                 local openPop = assert(io.popen(cmd, "r"))

--- a/lua/venv-selector/venv.lua
+++ b/lua/venv-selector/venv.lua
@@ -222,28 +222,28 @@ end
 
 -- Look for Poetry and Pipenv managed venv directories and search them.
 M.find_venv_manager_venvs = function()
-        local paths = {
-                config.settings.poetry_path,
-                config.settings.pipenv_path,
-                config.settings.pyenv_path,
-        }
-        for index, value in pairs(paths) do
-                if value == "" then
-                        table.remove(paths, index)
-                end
+    local paths = {
+        config.settings.poetry_path,
+        config.settings.pipenv_path,
+        config.settings.pyenv_path,
+    }
+    for index, value in pairs(paths) do
+        if value == "" then
+            table.remove(paths, index)
         end
-        local search_path_string = utils.create_fd_search_path_string(paths)
-        if search_path_string:len() ~= 0 then
-                local cmd = config.settings.fd_binary_name
-                        .. " . -HItd -tl --absolute-path --max-depth 1 --color never "
-                        .. search_path_string
-                dbg("Running search for venv manager venvs with: " .. cmd)
-                local openPop = assert(io.popen(cmd, "r"))
-                telescope.add_lines(openPop:lines(), "VenvManager")
-                openPop:close()
-        else
-                dbg("Found no venv manager directories to search for venvs.")
-        end
+    end
+    local search_path_string = utils.create_fd_search_path_string(paths)
+    if search_path_string:len() ~= 0 then
+      local cmd = config.settings.fd_binary_name
+        .. " . -HItd --absolute-path --max-depth 1 --color never "
+        .. search_path_string
+      dbg("Running search for venv manager venvs with: " .. cmd)
+      local openPop = assert(io.popen(cmd, "r"))
+      telescope.add_lines(openPop:lines(), "VenvManager")
+      openPop:close()
+    else
+      dbg("Found no venv manager directories to search for venvs.")
+    end
 end
 
 M.setup_dap_venv = function(venv_python)

--- a/lua/venv-selector/venv.lua
+++ b/lua/venv-selector/venv.lua
@@ -235,7 +235,7 @@ M.find_venv_manager_venvs = function()
 	local search_path_string = utils.create_fd_search_path_string(paths)
 	if search_path_string:len() ~= 0 then
 		local cmd = config.settings.fd_binary_name
-			.. " . -HItd --absolute-path --max-depth 1 --color never "
+			.. " . -HItd --tl --absolute-path --max-depth 1 --color never "
 			.. search_path_string
 		dbg("Running search for venv manager venvs with: " .. cmd)
 		local openPop = assert(io.popen(cmd, "r"))

--- a/lua/venv-selector/venv.lua
+++ b/lua/venv-selector/venv.lua
@@ -222,28 +222,28 @@ end
 
 -- Look for Poetry and Pipenv managed venv directories and search them.
 M.find_venv_manager_venvs = function()
-    local paths = {
-        config.settings.poetry_path,
-        config.settings.pipenv_path,
-        config.settings.pyenv_path,
-    }
-    for index, value in pairs(paths) do
-        if value == "" then
-            table.remove(paths, index)
+        local paths = {
+                config.settings.poetry_path,
+                config.settings.pipenv_path,
+                config.settings.pyenv_path,
+        }
+        for index, value in pairs(paths) do
+                if value == "" then
+                        table.remove(paths, index)
+                end
         end
-    end
-    local search_path_string = utils.create_fd_search_path_string(paths)
-    if search_path_string:len() ~= 0 then
-      local cmd = config.settings.fd_binary_name
-        .. " . -HItd --absolute-path --max-depth 1 --color never "
-        .. search_path_string
-      dbg("Running search for venv manager venvs with: " .. cmd)
-      local openPop = assert(io.popen(cmd, "r"))
-      telescope.add_lines(openPop:lines(), "VenvManager")
-      openPop:close()
-    else
-      dbg("Found no venv manager directories to search for venvs.")
-    end
+        local search_path_string = utils.create_fd_search_path_string(paths)
+        if search_path_string:len() ~= 0 then
+                local cmd = config.settings.fd_binary_name
+                        .. " . -HItd --absolute-path --max-depth 1 --color never "
+                        .. search_path_string
+                dbg("Running search for venv manager venvs with: " .. cmd)
+                local openPop = assert(io.popen(cmd, "r"))
+                telescope.add_lines(openPop:lines(), "VenvManager")
+                openPop:close()
+        else
+                dbg("Found no venv manager directories to search for venvs.")
+        end
 end
 
 M.setup_dap_venv = function(venv_python)

--- a/lua/venv-selector/venv.lua
+++ b/lua/venv-selector/venv.lua
@@ -222,28 +222,28 @@ end
 
 -- Look for Poetry and Pipenv managed venv directories and search them.
 M.find_venv_manager_venvs = function()
-    local paths = {
-        config.settings.poetry_path,
-        config.settings.pipenv_path,
-        config.settings.pyenv_path,
-    }
-    for index, value in pairs(paths) do
-        if value == "" then
-            table.remove(paths, index)
-        end
+  local paths = {
+    config.settings.poetry_path,
+    config.settings.pipenv_path,
+    config.settings.pyenv_path,
+  }
+  for index, value in pairs(paths) do
+    if value == "" then
+      table.remove(paths, index)
     end
-    local search_path_string = utils.create_fd_search_path_string(paths)
-    if search_path_string:len() ~= 0 then
-      local cmd = config.settings.fd_binary_name
-        .. " . -HItd --absolute-path --max-depth 1 --color never "
-        .. search_path_string
-      dbg("Running search for venv manager venvs with: " .. cmd)
-      local openPop = assert(io.popen(cmd, "r"))
-      telescope.add_lines(openPop:lines(), "VenvManager")
-      openPop:close()
-    else
-      dbg("Found no venv manager directories to search for venvs.")
-    end
+  end
+	local search_path_string = utils.create_fd_search_path_string(paths)
+	if search_path_string:len() ~= 0 then
+		local cmd = config.settings.fd_binary_name
+			.. " . -HItd --absolute-path --max-depth 1 --color never "
+			.. search_path_string
+		dbg("Running search for venv manager venvs with: " .. cmd)
+		local openPop = assert(io.popen(cmd, "r"))
+		telescope.add_lines(openPop:lines(), "VenvManager")
+		openPop:close()
+	else
+		dbg("Found no venv manager directories to search for venvs.")
+	end
 end
 
 M.setup_dap_venv = function(venv_python)

--- a/lua/venv-selector/venv.lua
+++ b/lua/venv-selector/venv.lua
@@ -235,7 +235,7 @@ M.find_venv_manager_venvs = function()
 	local search_path_string = utils.create_fd_search_path_string(paths)
 	if search_path_string:len() ~= 0 then
 		local cmd = config.settings.fd_binary_name
-			.. " . -HItd --tl --absolute-path --max-depth 1 --color never "
+			.. " . -HItd -tl --absolute-path --max-depth 1 --color never "
 			.. search_path_string
 		dbg("Running search for venv manager venvs with: " .. cmd)
 		local openPop = assert(io.popen(cmd, "r"))

--- a/lua/venv-selector/venv.lua
+++ b/lua/venv-selector/venv.lua
@@ -222,7 +222,16 @@ end
 
 -- Look for Poetry and Pipenv managed venv directories and search them.
 M.find_venv_manager_venvs = function()
-	local paths = { config.settings.poetry_path, config.settings.pipenv_path }
+  local paths = {
+    config.settings.poetry_path,
+    config.settings.pipenv_path,
+    config.settings.pyenv_path,
+  }
+  for index, value in pairs(paths) do
+    if value == "" then
+      table.remove(paths, index)
+    end
+  end
 	local search_path_string = utils.create_fd_search_path_string(paths)
 	if search_path_string:len() ~= 0 then
 		local cmd = config.settings.fd_binary_name

--- a/lua/venv-selector/venv.lua
+++ b/lua/venv-selector/venv.lua
@@ -222,28 +222,28 @@ end
 
 -- Look for Poetry and Pipenv managed venv directories and search them.
 M.find_venv_manager_venvs = function()
-  local paths = {
-    config.settings.poetry_path,
-    config.settings.pipenv_path,
-    config.settings.pyenv_path,
-  }
-  for index, value in pairs(paths) do
-    if value == "" then
-      table.remove(paths, index)
+    local paths = {
+        config.settings.poetry_path,
+        config.settings.pipenv_path,
+        config.settings.pyenv_path,
+    }
+    for index, value in pairs(paths) do
+        if value == "" then
+            table.remove(paths, index)
+        end
     end
-  end
-	local search_path_string = utils.create_fd_search_path_string(paths)
-	if search_path_string:len() ~= 0 then
-		local cmd = config.settings.fd_binary_name
-			.. " . -HItd --absolute-path --max-depth 1 --color never "
-			.. search_path_string
-		dbg("Running search for venv manager venvs with: " .. cmd)
-		local openPop = assert(io.popen(cmd, "r"))
-		telescope.add_lines(openPop:lines(), "VenvManager")
-		openPop:close()
-	else
-		dbg("Found no venv manager directories to search for venvs.")
-	end
+    local search_path_string = utils.create_fd_search_path_string(paths)
+    if search_path_string:len() ~= 0 then
+      local cmd = config.settings.fd_binary_name
+        .. " . -HItd --absolute-path --max-depth 1 --color never "
+        .. search_path_string
+      dbg("Running search for venv manager venvs with: " .. cmd)
+      local openPop = assert(io.popen(cmd, "r"))
+      telescope.add_lines(openPop:lines(), "VenvManager")
+      openPop:close()
+    else
+      dbg("Found no venv manager directories to search for venvs.")
+    end
 end
 
 M.setup_dap_venv = function(venv_python)

--- a/lua/venv-selector/venv.lua
+++ b/lua/venv-selector/venv.lua
@@ -227,11 +227,6 @@ M.find_venv_manager_venvs = function()
     config.settings.pipenv_path,
     config.settings.pyenv_path,
   }
-  for index, value in pairs(paths) do
-    if value == "" then
-      table.remove(paths, index)
-    end
-  end
 	local search_path_string = utils.create_fd_search_path_string(paths)
 	if search_path_string:len() ~= 0 then
 		local cmd = config.settings.fd_binary_name


### PR DESCRIPTION
Hello folks!

From the discussion on #18 I decided to try to start the implementation (Thanks @linux-cultist for setting the path).
There are a few things missing:

- [x]  Windows and Mac default paths for pyenv
- [x] Documentation

~~I also wanted to add a way to disable some managers to avoid noise and decided to go with disabling it using an empty string `""`, not sure there's a better way in Lua (I'm fairly new to the language).~~ **(Removed as per suggestion)**

Last but not least, I'm really sorry about the indentation mess. My editor uses 2 spaces as default and I was trying to fix it manually but it got messy :rofl: 
I'd love to know how/what to configure in order to comply with the style (=

closes #18 