### PR TITLE
Don't display error if cached venv was not found

### DIFF
--- a/lua/venv-selector/venv.lua
+++ b/lua/venv-selector/venv.lua
@@ -279,7 +279,6 @@ M.retrieve_from_cache = function()
 			end
 		end
 	end
-	utils.error("Error reading cache")
 end
 
 M.cache_venv = function(venv)


### PR DESCRIPTION
Fixes #26 