### PR TITLE
Fix: Can't open file %APPDATA%\venv-selector\venvs.json for writing

### DIFF
--- a/lua/venv-selector/system.lua
+++ b/lua/venv-selector/system.lua
@@ -49,7 +49,7 @@ end
 
 M.get_cache_default_path = function()
 	if M.sysname == "Windows_NT" then
-		return "%APPDATA%\\venv-selector\\"
+		return vim.fn.getenv("APPDATA") .. "\\venv-selector\\"
 	end
 	local user = vim.fn.getenv("USER")
 	if M.sysname == "Darwin" then


### PR DESCRIPTION
From the issue: https://github.com/linux-cultist/venv-selector.nvim/issues/28#issue-1748343756

When select a venv on Windows，you get an error:

```
E5108: Error executing lua Vim:E482: Can't open file %APPDATA%\venv-selector\venvs.json for writing: no such file or directory
stack traceback:
        [C]: in function 'writefile'
        ...-data/lazy/venv-selector.nvim/lua/venv-selector/venv.lua:303: in function 'cache_venv'
        ...-data/lazy/venv-selector.nvim/lua/venv-selector/venv.lua:207: in function 'activate_venv'
        .../lazy/venv-selector.nvim/lua/venv-selector/telescope.lua:76: in function 'key_func'
        ...nvim-data/lazy/telescope.nvim/lua/telescope/mappings.lua:352: in function 'execute_keymap'
        [string ":lua"]:1: in main chunk
Press ENTER or type command to continue```
```