### PR TITLE
Fix Hatch path on Darwin

### DIFF
--- a/lua/venv-selector/system.lua
+++ b/lua/venv-selector/system.lua
@@ -18,7 +18,7 @@ local M = {
     },
     Hatch = {
       Linux = "~/.local/share/hatch/env/virtual",
-      Darwin = "~/Library/Application Support/hatch/env/virtual",
+      Darwin = "~/Library/Application\\ Support/hatch/env/virtual",
       Windows_NT = "%USERPROFILE%\\AppData\\Local\\hatch\\env\\virtual",
     },
     VenvWrapper = {


### PR DESCRIPTION
@linux-cultist I have been unable to load it locally with `lazynvim`, so I can't tell if it works 😅

Any pointers?