### PR TITLE
fix default poetry path

### DIFF
--- a/lua/venv-selector/system.lua
+++ b/lua/venv-selector/system.lua
@@ -2,7 +2,7 @@ local M = {
   sysname = vim.loop.os_uname().sysname,
   venv_manager_default_paths = {
     Poetry = {
-      Linux = "~/.cache/pypoetry/virtual envs",
+      Linux = "~/.cache/pypoetry/virtualenvs",
       Darwin = "~/Library/Caches/pypoetry/virtualenvs",
       Windows_NT = "%APPDATA%\\pypoetry\\virtualenvs",
     },


### PR DESCRIPTION
Removed the space in the path as it is incorrect. Since the last update my venv selection has been empty and now I know why :)