### PR TITLE
Another way to refresh telescope

### DIFF
--- a/lua/venv-selector/init.lua
+++ b/lua/venv-selector/init.lua
@@ -2,6 +2,7 @@ local venv = require("venv-selector.venv")
 local config = require("venv-selector.config")
 local user_commands = require("venv-selector.user_commands")
 local dbg = require("venv-selector.utils").dbg
+local mytelescope = require("venv-selector.mytelescope")
 local hooks = require("venv-selector.hooks")
 local utils = require("venv-selector.utils")
 
@@ -13,7 +14,7 @@ M = {
     dbg(config.settings)
 
     -- Create the VenvSelect command.
-    user_commands.setup_user_commands("VenvSelect", M.reload, "Use VenvSelect to activate a venv")
+    user_commands.setup_user_commands("VenvSelect", M.open, "Use VenvSelect to activate a venv")
     user_commands.setup_user_commands(
       "VenvSelectCached",
       M.retrieve_from_cache,
@@ -42,8 +43,8 @@ M = {
     return venv.current_venv
   end,
   -- The main function runs when user executes VenvSelect command
-  reload = function()
-    venv.reload()
+  open = function()
+    mytelescope.open()
   end,
   deactivate_venv = function()
     venv.deactivate_venv()

--- a/lua/venv-selector/mytelescope.lua
+++ b/lua/venv-selector/mytelescope.lua
@@ -155,7 +155,12 @@ M.open = function()
 
       map("i", "<C-r>", function()
         M.remove_results()
-        venv.load({ force_refresh = true })
+        local picker = M.actions_state.get_current_picker(bufnr)
+        -- Delay by 10ms to achieve the refresh animation.
+        picker:refresh(finder, { reset_prompt = true })
+        vim.defer_fn(function()
+          venv.load({ force_refresh = true })
+        end, 10)
       end)
 
       return true


### PR DESCRIPTION
#46 

Summary of changes:
- `mytelescope.show_results` only refresh telescope now, the part of code of show new picker now move to `mytelescope.open`.
- `venv.reload` rename to `venv.load`. And, move some condition to `mytelescope.open`.
- delay by 10ms when refresh to achieve a visual refresh effect.

<details> 
  <summary>Before</summary>
  
  https://github.com/linux-cultist/venv-selector.nvim/assets/32055974/adfe1c7c-c6e8-491f-b082-026ada93bb01
</details>

<details> 
  <summary>After</summary>
  
  https://github.com/linux-cultist/venv-selector.nvim/assets/32055974/2574bb79-dbf9-4713-9f25-8d71c7a5c05d
</details>



