### PR TITLE
User nil

### DIFF
--- a/lua/venv-selector/system.lua
+++ b/lua/venv-selector/system.lua
@@ -83,14 +83,7 @@ function M.get_cache_default_path()
   if M.sysname == "Windows_NT" then
     return vim.fn.getenv("APPDATA") .. "\\venv-selector\\"
   end
-  local user = vim.fn.getenv("USER")
-  if M.sysname == "Darwin" then
-    return "/Users/" .. user .. "/.cache/venv-selector/"
-  end
-  if user == vim.NIL or user == "" then
-    return "/root/.cache/venv-selector/"
-  end
-  return "/home/" .. user .. "/.cache/venv-selector/"
+  return vim.env.HOME .. "/.cache/venv-selector/" 
 end
 
 function M.get_info()

--- a/lua/venv-selector/system.lua
+++ b/lua/venv-selector/system.lua
@@ -87,7 +87,7 @@ function M.get_cache_default_path()
   if M.sysname == "Darwin" then
     return "/Users/" .. user .. "/.cache/venv-selector/"
   end
-  if user == nil then
+  if user == nil or user == "" then
     return "/root/.cache/venv-selector/"
   end
   return "/home/" .. user .. "/.cache/venv-selector/"

--- a/lua/venv-selector/system.lua
+++ b/lua/venv-selector/system.lua
@@ -87,7 +87,7 @@ function M.get_cache_default_path()
   if M.sysname == "Darwin" then
     return "/Users/" .. user .. "/.cache/venv-selector/"
   end
-  if user == nil or user == "" then
+  if user == vim.NIL or user == "" then
     return "/root/.cache/venv-selector/"
   end
   return "/home/" .. user .. "/.cache/venv-selector/"

--- a/lua/venv-selector/system.lua
+++ b/lua/venv-selector/system.lua
@@ -87,7 +87,7 @@ function M.get_cache_default_path()
   if M.sysname == "Darwin" then
     return "/Users/" .. user .. "/.cache/venv-selector/"
   end
-  if user == nil
+  if user == nil then
     return "/root/.cache/venv-selector/"
   end
   return "/home/" .. user .. "/.cache/venv-selector/"

--- a/lua/venv-selector/system.lua
+++ b/lua/venv-selector/system.lua
@@ -87,6 +87,9 @@ function M.get_cache_default_path()
   if M.sysname == "Darwin" then
     return "/Users/" .. user .. "/.cache/venv-selector/"
   end
+  if user == nil
+    return "/root/.cache/venv-selector/"
+  end
   return "/home/" .. user .. "/.cache/venv-selector/"
 end
 


### PR DESCRIPTION
fix: added case where user is root and vim.fn.getenv("USER") returns vim.NIL