### PR TITLE
Fix Windows $PATH entry separator character

### DIFF
--- a/lua/venv-selector/system.lua
+++ b/lua/venv-selector/system.lua
@@ -85,6 +85,14 @@ function M.get_path_separator()
   end
 end
 
+function M.get_path_env_separator()
+  if M.sysname == "Windows_NT" then
+    return ";"
+  else
+    return ":"
+  end
+end
+
 function M.get_cache_default_path()
   if M.sysname == "Windows_NT" then
     return vim.fn.getenv("APPDATA") .. "\\venv-selector\\"
@@ -94,13 +102,15 @@ end
 
 function M.get_info()
   --- @class SystemInfo
-  --- @field sysname string System namme
+  --- @field sysname string System name
   --- @field path_sep string Path separator appropriate for user system
+  --- @field path_env_sep string System-specific $PATH entry separator
   --- @field python_name string Name of Python binary
   --- @field python_parent_path string Directory containing Python binary on user system
   return {
     sysname = vim.loop.os_uname().sysname,
     path_sep = M.get_path_separator(),
+    path_env_sep = M.get_path_env_separator(),
     python_name = M.get_python_name(),
     python_parent_path = M.get_python_parent_path(),
   }

--- a/lua/venv-selector/venv.lua
+++ b/lua/venv-selector/venv.lua
@@ -106,11 +106,11 @@ function M.set_venv_and_system_paths(venv_row)
 
   -- Remove previous bin path from path
   if prev_bin_path ~= nil then
-    current_system_path = string.gsub(current_system_path, utils.escape_pattern(prev_bin_path .. ":"), "")
+    current_system_path = string.gsub(current_system_path, utils.escape_pattern(prev_bin_path .. sys.path_env_sep), "")
   end
 
   -- Add new bin path to path
-  local new_system_path = new_bin_path .. ":" .. current_system_path
+  local new_system_path = new_bin_path .. sys.path_env_sep .. current_system_path
   vim.fn.setenv("PATH", new_system_path)
   M.current_bin_path = new_bin_path
 
@@ -128,7 +128,7 @@ function M.deactivate_venv()
   local prev_bin_path = M.current_bin_path
 
   if prev_bin_path ~= nil then
-    current_system_path = string.gsub(current_system_path, utils.escape_pattern(prev_bin_path .. ":"), "")
+    current_system_path = string.gsub(current_system_path, utils.escape_pattern(prev_bin_path .. sys.path_env_sep), "")
     vim.fn.setenv("PATH", current_system_path)
   end
 


### PR DESCRIPTION
Windows uses `;` to separate entries in the `PATH` environment variable. This was hardcoded to `:` which meant that a terminal in nvim wouldn't find the venv's `Scripts` directory.

Also fixes a small typo in `sys.get_info()`.