### PR TITLE
Add PDM as a python dependency manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Browse existing python virtual environments on your computer and select one to a
 - Currently supports virtual environments created in:
   - [Python](https://www.python.org/) (`python3 -m venv venv`)
   - [Poetry](https://python-poetry.org)
+  - PDM
   - [Pipenv](https://pipenv.pypa.io/en/latest/)
   - [Anaconda](https://www.anaconda.com)
   - [Pyenv](https://github.com/pyenv/pyenv)
@@ -98,7 +99,7 @@ Look into options like `parents` and `name` to change the specifics of this kind
 
 **Venv Manager Search**
 
-`VenvSelect` looks for virtual environments managed by Poetry, Pipenv, Anaconda etc in specific locations where they normally are. This kind of search
+`VenvSelect` looks for virtual environments managed by Poetry, PDM, Pipenv, Anaconda etc in specific locations where they normally are. This kind of search
 does not go up to parent directories - it just looks in the specific default folders on your machine.
 
 Look into options like `poetry_path`, `pipenv_path` etc to change where the plugin will look. The options `name` or `parents` has no effect on this search.
@@ -121,6 +122,7 @@ Neovim when you have a file opened and your LSP has started. `VenvSelect` looks 
 | fd_binary_name          | fd                                                                                                       | `VenvSelect` also tries to find other names for the same program, like `fdfind` and `fd-find` and will use those if found. But you can set something specific here if you need to.                                                                                                                                                                                                                        |
 | notify_user_on_activate | true                                                                                                     | `VenvSelect` will notify you with a message when a venv is selected in the user interface.                                                                                                                                                                                                                                                                                                                |
 | poetry_path             | [system.lua](https://github.com/linux-cultist/venv-selector.nvim/blob/main/lua/venv-selector/system.lua) | The default path on your system where the plugin looks for Poetry venvs.                                                                                                                                                                                                                                                                                                                                  |
+| pdm_path                | [system.lua](https://github.com/linux-cultist/venv-selector.nvim/blob/main/lua/venv-selector/system.lua) | The default path on your system where the plugin looks for PDM venvs.                                                                                                                                                                                                                                                                                                                                  |
 | pipenv_path             | [system.lua](https://github.com/linux-cultist/venv-selector.nvim/blob/main/lua/venv-selector/system.lua) | The default path on your system where the plugin looks for Pipenv venvs.                                                                                                                                                                                                                                                                                                                                  |
 | pyenv_path              | [system.lua](https://github.com/linux-cultist/venv-selector.nvim/blob/main/lua/venv-selector/system.lua) | The default path on your system where the plugin looks for Pyenv venvs.                                                                                                                                                                                                                                                                                                                                   |
 | hatch_path              | [system.lua](https://github.com/linux-cultist/venv-selector.nvim/blob/main/lua/venv-selector/system.lua) | The default path on your system where the plugin looks for Hatch venvs.                                                                                                                                                                                                                                                                                                                                   |

--- a/lua/venv-selector/config.lua
+++ b/lua/venv-selector/config.lua
@@ -13,6 +13,7 @@ M.default_settings = {
 	search_venv_managers = true,
 	parents = 2, -- When search is true, go this many directories up from the current opened buffer
 	poetry_path = system.get_venv_manager_default_path("Poetry"),
+	pdm_path = system.get_venv_manager_default_path("PDM"),
 	pipenv_path = system.get_venv_manager_default_path("Pipenv"),
 	pyenv_path = system.get_venv_manager_default_path("Pyenv"),
 	anaconda_base_path = system.get_venv_manager_default_path("AnacondaBase"),

--- a/lua/venv-selector/system.lua
+++ b/lua/venv-selector/system.lua
@@ -1,119 +1,123 @@
 local M = {}
 
 function M.getenv(var)
-  local v = os.getenv(var)
-  if v == nil then
-    return ""
-  else
-    return v
-  end
+	local v = os.getenv(var)
+	if v == nil then
+		return ""
+	else
+		return v
+	end
 end
 
 -- Use M.getenv here because env variables like $CONDA_PREFIX doesnt get resolved automatically (but $HOME and ~ does).
 M.venv_manager_default_paths = {
-  Poetry = {
-    Linux = "~/.cache/pypoetry/virtualenvs",
-    Darwin = "~/Library/Caches/pypoetry/virtualenvs",
-    Windows_NT = M.getenv("APPDATA" .. "\\pypoetry\\virtualenvs"),
-  },
-  Pipenv = {
-    Linux = "~/.local/share/virtualenvs",
-    Darwin = "~/.local/share/virtualenvs",
-    Windows_NT = "~\\virtualenvs",
-  },
-  Pyenv = {
-    Linux = "~/.pyenv/versions",
-    Darwin = "~/.pyenv/versions",
-    Windows_NT = M.getenv("USERPROFILE") .. "\\.pyenv\\versions",
-  },
-  Hatch = {
-    Linux = "~/.local/share/hatch/env/virtual",
-    Darwin = "~/Library/Application/Support/hatch/env/virtual",
-    Windows_NT = M.getenv("USERPROFILE") .. "\\AppData\\Local\\hatch\\env\\virtual",
-  },
-  VenvWrapper = {
-    Linux = "~/.virtualenvs",
-    Darwin = "~/.virtualenvs",
-    Windows_NT = M.getenv("USERPROFILE") .. ".virtualenvs", -- VenvWrapper not supported on Windows but need something here
-  },
-  AnacondaBase = {
-    Linux = M.getenv("CONDA_PREFIX"),
-    Darwin = M.getenv("CONDA_PREFIX"),
-    Windows_NT = M.getenv("CONDA_PREFIX"),
-  },
-  AnacondaEnvs = {
-    Linux = M.getenv("HOME") .. "/.conda/envs",
-    Darwin = M.getenv("HOME") .. "/.conda/envs",
-    Windows_NT = M.getenv("HOME") .. "./conda/envs",
-  },
+	Poetry = {
+		Linux = "~/.cache/pypoetry/virtualenvs",
+		Darwin = "~/Library/Caches/pypoetry/virtualenvs",
+		Windows_NT = M.getenv("APPDATA" .. "\\pypoetry\\virtualenvs"),
+	},
+	PDM = {
+		Linux = "~/.local/share/venvs",
+		Darwin = "~/.local/share/venvs",
+		Windows_NT = M.getenv("APPDATA" .. "\\venvs"),
+	},
+	Pipenv = {
+		Linux = "~/.local/share/virtualenvs",
+		Darwin = "~/.local/share/virtualenvs",
+		Windows_NT = "~\\virtualenvs",
+	},
+	Pyenv = {
+		Linux = "~/.pyenv/versions",
+		Darwin = "~/.pyenv/versions",
+		Windows_NT = M.getenv("USERPROFILE") .. "\\.pyenv\\versions",
+	},
+	Hatch = {
+		Linux = "~/.local/share/hatch/env/virtual",
+		Darwin = "~/Library/Application/Support/hatch/env/virtual",
+		Windows_NT = M.getenv("USERPROFILE") .. "\\AppData\\Local\\hatch\\env\\virtual",
+	},
+	VenvWrapper = {
+		Linux = "~/.virtualenvs",
+		Darwin = "~/.virtualenvs",
+		Windows_NT = M.getenv("USERPROFILE") .. ".virtualenvs", -- VenvWrapper not supported on Windows but need something here
+	},
+	AnacondaBase = {
+		Linux = M.getenv("CONDA_PREFIX"),
+		Darwin = M.getenv("CONDA_PREFIX"),
+		Windows_NT = M.getenv("CONDA_PREFIX"),
+	},
+	AnacondaEnvs = {
+		Linux = M.getenv("HOME") .. "/.conda/envs",
+		Darwin = M.getenv("HOME") .. "/.conda/envs",
+		Windows_NT = M.getenv("HOME") .. "./conda/envs",
+	},
 }
-
 
 M.sysname = vim.loop.os_uname().sysname
 
 function M.get_venv_manager_default_path(venv_manager_name)
-  return M.venv_manager_default_paths[venv_manager_name][M.sysname]
+	return M.venv_manager_default_paths[venv_manager_name][M.sysname]
 end
 
 function M.get_python_parent_path()
-  local config = require("venv-selector.config")
-  local parent_dir = config.settings.anaconda.python_parent_dir
+	local config = require("venv-selector.config")
+	local parent_dir = config.settings.anaconda.python_parent_dir
 
-  if M.sysname == "Linux" or M.sysname == "Darwin" then
-    return parent_dir or "bin"
-  else
-    return parent_dir or "Scripts"
-  end
+	if M.sysname == "Linux" or M.sysname == "Darwin" then
+		return parent_dir or "bin"
+	else
+		return parent_dir or "Scripts"
+	end
 end
 
 function M.get_python_name()
-  local config = require("venv-selector.config")
-  local python_executable = config.settings.anaconda.python_executable
+	local config = require("venv-selector.config")
+	local python_executable = config.settings.anaconda.python_executable
 
-  if M.sysname == "Linux" or M.sysname == "Darwin" then
-    return python_executable or "python"
-  else
-    return python_executable or "python.exe"
-  end
+	if M.sysname == "Linux" or M.sysname == "Darwin" then
+		return python_executable or "python"
+	else
+		return python_executable or "python.exe"
+	end
 end
 
 function M.get_path_separator()
-  if M.sysname == "Linux" or M.sysname == "Darwin" then
-    return "/"
-  else
-    return "\\"
-  end
+	if M.sysname == "Linux" or M.sysname == "Darwin" then
+		return "/"
+	else
+		return "\\"
+	end
 end
 
 function M.get_path_env_separator()
-  if M.sysname == "Windows_NT" then
-    return ";"
-  else
-    return ":"
-  end
+	if M.sysname == "Windows_NT" then
+		return ";"
+	else
+		return ":"
+	end
 end
 
 function M.get_cache_default_path()
-  if M.sysname == "Windows_NT" then
-    return vim.fn.getenv("APPDATA") .. "\\venv-selector\\"
-  end
-  return vim.env.HOME .. "/.cache/venv-selector/"
+	if M.sysname == "Windows_NT" then
+		return vim.fn.getenv("APPDATA") .. "\\venv-selector\\"
+	end
+	return vim.env.HOME .. "/.cache/venv-selector/"
 end
 
 function M.get_info()
-  --- @class SystemInfo
-  --- @field sysname string System name
-  --- @field path_sep string Path separator appropriate for user system
-  --- @field path_env_sep string System-specific $PATH entry separator
-  --- @field python_name string Name of Python binary
-  --- @field python_parent_path string Directory containing Python binary on user system
-  return {
-    sysname = vim.loop.os_uname().sysname,
-    path_sep = M.get_path_separator(),
-    path_env_sep = M.get_path_env_separator(),
-    python_name = M.get_python_name(),
-    python_parent_path = M.get_python_parent_path(),
-  }
+	--- @class SystemInfo
+	--- @field sysname string System name
+	--- @field path_sep string Path separator appropriate for user system
+	--- @field path_env_sep string System-specific $PATH entry separator
+	--- @field python_name string Name of Python binary
+	--- @field python_parent_path string Directory containing Python binary on user system
+	return {
+		sysname = vim.loop.os_uname().sysname,
+		path_sep = M.get_path_separator(),
+		path_env_sep = M.get_path_env_separator(),
+		python_name = M.get_python_name(),
+		python_parent_path = M.get_python_parent_path(),
+	}
 end
 
 return M

--- a/lua/venv-selector/venv.lua
+++ b/lua/venv-selector/venv.lua
@@ -6,57 +6,56 @@ local config = require("venv-selector.config")
 
 local M = {}
 
-
 M.current_python_path = nil -- Contains path to current python if activated, nil otherwise
-M.current_venv = nil        -- Contains path to current venv folder if activated, nil otherwise
-M.current_bin_path = nil    -- Keeps track of old system path so we can remove it when adding a new one
+M.current_venv = nil -- Contains path to current venv folder if activated, nil otherwise
+M.current_bin_path = nil -- Keeps track of old system path so we can remove it when adding a new one
 M.fd_handle = nil
 M.path_to_search = nil
 
 function M.load(action)
-  local act = action or {}
+	local act = action or {}
 
-  local ready_for_new_search = M.fd_handle == nil or M.fd_handle:is_closing() == true
-  if ready_for_new_search == false then
-    dbg("Cannot start a new search while old one is running.")
-    return
-  end
+	local ready_for_new_search = M.fd_handle == nil or M.fd_handle:is_closing() == true
+	if ready_for_new_search == false then
+		dbg("Cannot start a new search while old one is running.")
+		return
+	end
 
-  local buffer_dir = config.get_buffer_dir()
+	local buffer_dir = config.get_buffer_dir()
 
-  -- Only search for parent venvs if search option is true
-  if config.settings.search == true then
-    if act.force_refresh == true then
-      if M.path_to_search == nil then
-        dbg("No previous search path when asked to refresh results.")
-        M.path_to_search = utils.find_parent_dir(buffer_dir, config.settings.parents)
-        M.find_parent_venvs(M.path_to_search)
-      else
-        dbg("User refreshed results - buffer_dir is: " .. buffer_dir)
-        M.path_to_search = utils.find_parent_dir(buffer_dir, config.settings.parents)
-        M.find_parent_venvs(M.path_to_search)
-      end
-    else
-      M.path_to_search = utils.find_parent_dir(buffer_dir, config.settings.parents)
-      M.find_parent_venvs(M.path_to_search)
-    end
-  else
-    M.find_other_venvs()
-  end
+	-- Only search for parent venvs if search option is true
+	if config.settings.search == true then
+		if act.force_refresh == true then
+			if M.path_to_search == nil then
+				dbg("No previous search path when asked to refresh results.")
+				M.path_to_search = utils.find_parent_dir(buffer_dir, config.settings.parents)
+				M.find_parent_venvs(M.path_to_search)
+			else
+				dbg("User refreshed results - buffer_dir is: " .. buffer_dir)
+				M.path_to_search = utils.find_parent_dir(buffer_dir, config.settings.parents)
+				M.find_parent_venvs(M.path_to_search)
+			end
+		else
+			M.path_to_search = utils.find_parent_dir(buffer_dir, config.settings.parents)
+			M.find_parent_venvs(M.path_to_search)
+		end
+	else
+		M.find_other_venvs()
+	end
 end
 
 -- This gets called as soon as the parent venv search is done.
 function M.find_other_venvs(event)
-  event = event or {}
-  if config.settings.search_workspace == true then
-    M.find_workspace_venvs()
-  end
+	event = event or {}
+	if config.settings.search_workspace == true then
+		M.find_workspace_venvs()
+	end
 
-  if config.settings.search_venv_managers == true then
-    M.find_venv_manager_venvs()
-  end
+	if config.settings.search_venv_managers == true then
+		M.find_venv_manager_venvs()
+	end
 
-  mytelescope.show_results()
+	mytelescope.show_results()
 end
 
 -- Manages the paths to python since they are different on Linux, Mac and Windows
@@ -65,273 +64,280 @@ end
 -- differs between Linux, Mac and Windows. This function sets up the correct full path
 -- to python, adds it to the system path and sets the VIRTUAL_ENV variable.
 function M.set_venv_and_system_paths(venv_row)
-  dbg("Getting local system info...")
-  local sys = system.get_info()
-  dbg(sys)
-  local venv_path = venv_row.value
-  local new_bin_path
-  local venv_python
+	dbg("Getting local system info...")
+	local sys = system.get_info()
+	dbg(sys)
+	local venv_path = venv_row.value
+	local new_bin_path
+	local venv_python
 
-  if sys.python_parent_path:len() == 0 then
-    -- If we dont have a python_parent_path (user may have set it to an empty string), use just the venv_path
-    new_bin_path = venv_path
-    venv_python = new_bin_path .. sys.path_sep .. sys.python_name
-  else
-    new_bin_path = venv_path .. sys.path_sep .. sys.python_parent_path
-    venv_python = new_bin_path .. sys.path_sep .. sys.python_name
-  end
+	if sys.python_parent_path:len() == 0 then
+		-- If we dont have a python_parent_path (user may have set it to an empty string), use just the venv_path
+		new_bin_path = venv_path
+		venv_python = new_bin_path .. sys.path_sep .. sys.python_name
+	else
+		new_bin_path = venv_path .. sys.path_sep .. sys.python_parent_path
+		venv_python = new_bin_path .. sys.path_sep .. sys.python_name
+	end
 
-  -- Make sure our python exists on disk before activating it, in case paths are wrong
-  if vim.fn.executable(venv_python) == 0 then
-    utils.notify("The python path '" .. venv_python .. "' doesnt exist.")
-    return
-  end
+	-- Make sure our python exists on disk before activating it, in case paths are wrong
+	if vim.fn.executable(venv_python) == 0 then
+		utils.notify("The python path '" .. venv_python .. "' doesnt exist.")
+		return
+	end
 
-  M.set_pythonpath(venv_python)
+	M.set_pythonpath(venv_python)
 
-  if config.settings.dap_enabled == true then
-    M.setup_dap_venv(venv_python)
-  end
+	if config.settings.dap_enabled == true then
+		M.setup_dap_venv(venv_python)
+	end
 
-  if config.settings.notify_user_on_activate == true then
-    utils.notify("Activated '" .. venv_python .. "'")
-  end
+	if config.settings.notify_user_on_activate == true then
+		utils.notify("Activated '" .. venv_python .. "'")
+	end
 
-  for _, hook in ipairs(config.settings.changed_venv_hooks) do
-    hook(venv_path, venv_python)
-  end
+	for _, hook in ipairs(config.settings.changed_venv_hooks) do
+		hook(venv_path, venv_python)
+	end
 
-  local current_system_path = vim.fn.getenv("PATH")
-  local prev_bin_path = M.current_bin_path
+	local current_system_path = vim.fn.getenv("PATH")
+	local prev_bin_path = M.current_bin_path
 
-  -- Remove previous bin path from path
-  if prev_bin_path ~= nil then
-    current_system_path = string.gsub(current_system_path, utils.escape_pattern(prev_bin_path .. sys.path_env_sep), "")
-  end
+	-- Remove previous bin path from path
+	if prev_bin_path ~= nil then
+		current_system_path =
+			string.gsub(current_system_path, utils.escape_pattern(prev_bin_path .. sys.path_env_sep), "")
+	end
 
-  -- Add new bin path to path
-  local new_system_path = new_bin_path .. sys.path_env_sep .. current_system_path
-  vim.fn.setenv("PATH", new_system_path)
-  M.current_bin_path = new_bin_path
+	-- Add new bin path to path
+	local new_system_path = new_bin_path .. sys.path_env_sep .. current_system_path
+	vim.fn.setenv("PATH", new_system_path)
+	M.current_bin_path = new_bin_path
 
-  -- Set VIRTUAL_ENV
-  vim.fn.setenv("VIRTUAL_ENV", venv_path)
+	-- Set VIRTUAL_ENV
+	vim.fn.setenv("VIRTUAL_ENV", venv_path)
 
-  M.current_python_path = venv_python
-  M.current_venv = venv_path
-  dbg("Finished setting venv and system paths.")
+	M.current_python_path = venv_python
+	M.current_venv = venv_path
+	dbg("Finished setting venv and system paths.")
 end
 
 function M.deactivate_venv()
-  -- Remove previous bin path from path
-  local current_system_path = vim.fn.getenv("PATH")
-  local prev_bin_path = M.current_bin_path
+	-- Remove previous bin path from path
+	local current_system_path = vim.fn.getenv("PATH")
+	local prev_bin_path = M.current_bin_path
 
-  if prev_bin_path ~= nil then
-    current_system_path = string.gsub(current_system_path, utils.escape_pattern(prev_bin_path .. sys.path_env_sep), "")
-    vim.fn.setenv("PATH", current_system_path)
-  end
+	if prev_bin_path ~= nil then
+		current_system_path =
+			string.gsub(current_system_path, utils.escape_pattern(prev_bin_path .. sys.path_env_sep), "")
+		vim.fn.setenv("PATH", current_system_path)
+	end
 
-  -- Remove VIRTUAL_ENV environment variable.
-  vim.fn.setenv("VIRTUAL_ENV", nil)
+	-- Remove VIRTUAL_ENV environment variable.
+	vim.fn.setenv("VIRTUAL_ENV", nil)
 
-  -- TODO: Set pyright to use system python if it exists.
-  -- Not sure how to do this in a cross platform compatible way.
+	-- TODO: Set pyright to use system python if it exists.
+	-- Not sure how to do this in a cross platform compatible way.
 
-  M.current_python_path = nil
-  M.current_venv = nil
+	M.current_python_path = nil
+	M.current_venv = nil
 end
 
 -- Start a search for venvs in all directories under the nstart_dir
 -- Async function to search for venvs - it will call VS.show_results() when its done by itself.
 function M.find_parent_venvs(parent_dir)
-  local stdout = vim.loop.new_pipe(false)
-  local stderr = vim.loop.new_pipe(false)
-  local venv_names = utils.create_fd_venv_names_regexp(config.settings.name)
+	local stdout = vim.loop.new_pipe(false)
+	local stderr = vim.loop.new_pipe(false)
+	local venv_names = utils.create_fd_venv_names_regexp(config.settings.name)
 
-  local fdconfig = {
-    args = { "--absolute-path", "--color", "never", "-E", "/proc", "-HItd", venv_names, parent_dir,
-    },
-    stdio = { nil, stdout, stderr },
-  }
+	local fdconfig = {
+		args = { "--absolute-path", "--color", "never", "-E", "/proc", "-HItd", venv_names, parent_dir },
+		stdio = { nil, stdout, stderr },
+	}
 
-  if config.settings.anaconda_base_path:len() > 0 then
-    table.insert(fdconfig, "-E")
-    table.insert(fdconfig, config.settings.anaconda_base_path)
-  end
+	if config.settings.anaconda_base_path:len() > 0 then
+		table.insert(fdconfig, "-E")
+		table.insert(fdconfig, config.settings.anaconda_base_path)
+	end
 
-  if config.settings.anaconda_envs_path:len() > 0 then
-    table.insert(fdconfig, "-E")
-    table.insert(fdconfig, config.settings.anaconda_envs_path)
-  end
+	if config.settings.anaconda_envs_path:len() > 0 then
+		table.insert(fdconfig, "-E")
+		table.insert(fdconfig, config.settings.anaconda_envs_path)
+	end
 
-  dbg("Looking for parent venvs in '" .. parent_dir .. "' using the following parameters:")
-  dbg(fdconfig.args)
+	dbg("Looking for parent venvs in '" .. parent_dir .. "' using the following parameters:")
+	dbg(fdconfig.args)
 
-  M.fd_handle = vim.loop.spawn(
-    config.settings.fd_binary_name,
-    fdconfig,
-    vim.schedule_wrap(function() -- on exit
-      stdout:read_stop()
-      stderr:read_stop()
-      stdout:close()
-      stderr:close()
-      M.find_other_venvs()
-      M.fd_handle:close()
-    end)
-  )
-  vim.loop.read_start(stdout, mytelescope.on_read)
+	M.fd_handle = vim.loop.spawn(
+		config.settings.fd_binary_name,
+		fdconfig,
+		vim.schedule_wrap(function() -- on exit
+			stdout:read_stop()
+			stderr:read_stop()
+			stdout:close()
+			stderr:close()
+			M.find_other_venvs()
+			M.fd_handle:close()
+		end)
+	)
+	vim.loop.read_start(stdout, mytelescope.on_read)
 end
 
 -- Hook into lspconfig so we can set the python to use.
 function M.set_pythonpath(python_path)
-  vim.api.nvim_create_autocmd({ "BufReadPost" }, {
-    pattern = { "*.py" },
-    callback = function()
-      local active_clients = {}
-      for _, client in ipairs(vim.lsp.get_active_clients({ name = "pyright", bufnr = vim.api.nvim_get_current_buf() })) do
-        table.insert(active_clients, client)
-      end
+	vim.api.nvim_create_autocmd({ "BufReadPost" }, {
+		pattern = { "*.py" },
+		callback = function()
+			local active_clients = {}
+			for _, client in
+				ipairs(vim.lsp.get_active_clients({ name = "pyright", bufnr = vim.api.nvim_get_current_buf() }))
+			do
+				table.insert(active_clients, client)
+			end
 
-      for _, client in ipairs(vim.lsp.get_active_clients({ name = "pylance", bufnr = vim.api.nvim_get_current_buf() })) do
-        table.insert(active_clients, client)
-      end
+			for _, client in
+				ipairs(vim.lsp.get_active_clients({ name = "pylance", bufnr = vim.api.nvim_get_current_buf() }))
+			do
+				table.insert(active_clients, client)
+			end
 
-      for _, client in ipairs(active_clients) do
-        client.config.settings = vim.tbl_deep_extend("force", client.config.settings,
-          { python = { pythonPath = python_path } })
+			for _, client in ipairs(active_clients) do
+				client.config.settings =
+					vim.tbl_deep_extend("force", client.config.settings, { python = { pythonPath = python_path } })
 
-        client.notify("workspace/didChangeConfiguration", { settings = nil })
-      end
-    end,
-  })
+				client.notify("workspace/didChangeConfiguration", { settings = nil })
+			end
+		end,
+	})
 end
 
 -- Gets called when user hits enter in the Telescope results dialog
 function M.activate_venv()
-  local actions_state = require("telescope.actions.state")
+	local actions_state = require("telescope.actions.state")
 
-  local selected_venv = actions_state.get_selected_entry()
-  if selected_venv ~= nil and selected_venv.value ~= nil then
-    dbg("User selected venv in telescope: " .. selected_venv.value)
-    M.set_venv_and_system_paths(selected_venv)
-    M.cache_venv(selected_venv)
-  end
+	local selected_venv = actions_state.get_selected_entry()
+	if selected_venv ~= nil and selected_venv.value ~= nil then
+		dbg("User selected venv in telescope: " .. selected_venv.value)
+		M.set_venv_and_system_paths(selected_venv)
+		M.cache_venv(selected_venv)
+	end
 end
 
 function M.list_pyright_workspace_folders()
-  local workspace_folders = {}
-  local workspace_folders_found = false
-  for _, client in pairs(vim.lsp.get_active_clients()) do
-    if vim.tbl_contains({ "pyright", "pylance" }, client.name) then
-      for _, folder in pairs(client.workspace_folders or {}) do
-        dbg("Found workspace folder: " .. folder.name)
-        table.insert(workspace_folders, folder.name)
-        workspace_folders_found = true
-      end
-    end
-  end
-  if workspace_folders_found == false then
-    dbg("No workspace folders found")
-  end
+	local workspace_folders = {}
+	local workspace_folders_found = false
+	for _, client in pairs(vim.lsp.get_active_clients()) do
+		if vim.tbl_contains({ "pyright", "pylance" }, client.name) then
+			for _, folder in pairs(client.workspace_folders or {}) do
+				dbg("Found workspace folder: " .. folder.name)
+				table.insert(workspace_folders, folder.name)
+				workspace_folders_found = true
+			end
+		end
+	end
+	if workspace_folders_found == false then
+		dbg("No workspace folders found")
+	end
 
-  return workspace_folders
+	return workspace_folders
 end
 
 -- Look for workspace venvs
 function M.find_workspace_venvs()
-  local workspace_folders = M.list_pyright_workspace_folders()
-  local search_path_string = utils.create_fd_search_path_string(workspace_folders)
-  if search_path_string:len() ~= 0 then
-    local search_path_regexp = utils.create_fd_venv_names_regexp(config.settings.name)
-    local cmd = config.settings.fd_binary_name
-        .. " -HItd --absolute-path --color never '"
-        .. search_path_regexp
-        .. "' "
-        .. search_path_string
-    dbg("Running search for workspace venvs with: " .. cmd)
-    local openPop = assert(io.popen(cmd, "r"))
-    mytelescope.add_lines(openPop:lines(), "Workspace")
-    openPop:close()
-  else
-    dbg("Found no workspaces to search for venvs.")
-  end
+	local workspace_folders = M.list_pyright_workspace_folders()
+	local search_path_string = utils.create_fd_search_path_string(workspace_folders)
+	if search_path_string:len() ~= 0 then
+		local search_path_regexp = utils.create_fd_venv_names_regexp(config.settings.name)
+		local cmd = config.settings.fd_binary_name
+			.. " -HItd --absolute-path --color never '"
+			.. search_path_regexp
+			.. "' "
+			.. search_path_string
+		dbg("Running search for workspace venvs with: " .. cmd)
+		local openPop = assert(io.popen(cmd, "r"))
+		mytelescope.add_lines(openPop:lines(), "Workspace")
+		openPop:close()
+	else
+		dbg("Found no workspaces to search for venvs.")
+	end
 end
 
 -- Look for Poetry and Pipenv managed venv directories and search them.
 function M.find_venv_manager_venvs()
-  local paths = {
-    config.settings.poetry_path,
-    config.settings.pipenv_path,
-    config.settings.pyenv_path,
-    config.settings.hatch_path,
-    config.settings.venvwrapper_path,
-    config.settings.anaconda_envs_path,
-  }
-  local search_path_string = utils.create_fd_search_path_string(paths)
-  if search_path_string:len() ~= 0 then
-    local cmd = config.settings.fd_binary_name
-        .. " . -HItd -tl --absolute-path --max-depth 1 --color never "
-        .. search_path_string .. " --exclude '3.*.*'"
-    dbg("Running search for venv manager venvs with: " .. cmd)
-    local openPop = assert(io.popen(cmd, "r"))
-    mytelescope.add_lines(openPop:lines(), "VenvManager")
-    openPop:close()
+	local paths = {
+		config.settings.poetry_path,
+		config.settings.pdm_path,
+		config.settings.pipenv_path,
+		config.settings.pyenv_path,
+		config.settings.hatch_path,
+		config.settings.venvwrapper_path,
+		config.settings.anaconda_envs_path,
+	}
+	local search_path_string = utils.create_fd_search_path_string(paths)
+	if search_path_string:len() ~= 0 then
+		local cmd = config.settings.fd_binary_name
+			.. " . -HItd -tl --absolute-path --max-depth 1 --color never "
+			.. search_path_string
+			.. " --exclude '3.*.*'"
+		dbg("Running search for venv manager venvs with: " .. cmd)
+		local openPop = assert(io.popen(cmd, "r"))
+		mytelescope.add_lines(openPop:lines(), "VenvManager")
+		openPop:close()
 
-    -- If $CONDA_PREFIX is defined and exists, add the path as an existing venv
-    if vim.fn.isdirectory(config.settings.anaconda_base_path) ~= 0 then
-      table.insert(
-        mytelescope.results,
-        { icon = "", path = utils.remove_last_slash(config.settings.anaconda_base_path .. "/") }
-      )
-    end
-  else
-    dbg("Found no venv manager directories to search for venvs.")
-  end
+		-- If $CONDA_PREFIX is defined and exists, add the path as an existing venv
+		if vim.fn.isdirectory(config.settings.anaconda_base_path) ~= 0 then
+			table.insert(
+				mytelescope.results,
+				{ icon = "", path = utils.remove_last_slash(config.settings.anaconda_base_path .. "/") }
+			)
+		end
+	else
+		dbg("Found no venv manager directories to search for venvs.")
+	end
 end
 
 function M.setup_dap_venv(venv_python)
-  require("dap-python").resolve_python = function()
-    return venv_python
-  end
+	require("dap-python").resolve_python = function()
+		return venv_python
+	end
 end
 
 function M.retrieve_from_cache()
-  if vim.fn.filereadable(config.settings.cache_file) == 1 then
-    local cache_file = vim.fn.readfile(config.settings.cache_file)
-    if cache_file ~= nil and cache_file[1] ~= nil then
-      local venv_cache = vim.fn.json_decode(cache_file[1])
-      if venv_cache ~= nil and venv_cache[vim.fn.getcwd()] ~= nil then
-        M.set_venv_and_system_paths(venv_cache[vim.fn.getcwd()])
-        return
-      end
-    end
-  end
+	if vim.fn.filereadable(config.settings.cache_file) == 1 then
+		local cache_file = vim.fn.readfile(config.settings.cache_file)
+		if cache_file ~= nil and cache_file[1] ~= nil then
+			local venv_cache = vim.fn.json_decode(cache_file[1])
+			if venv_cache ~= nil and venv_cache[vim.fn.getcwd()] ~= nil then
+				M.set_venv_and_system_paths(venv_cache[vim.fn.getcwd()])
+				return
+			end
+		end
+	end
 end
 
 function M.cache_venv(venv)
-  local venv_cache = {
-    [vim.fn.getcwd()] = { value = venv.value },
-  }
+	local venv_cache = {
+		[vim.fn.getcwd()] = { value = venv.value },
+	}
 
-  if vim.fn.filewritable(config.settings.cache_file) == 0 then
-    vim.fn.mkdir(vim.fn.expand(config.settings.cache_dir), "p")
-  end
+	if vim.fn.filewritable(config.settings.cache_file) == 0 then
+		vim.fn.mkdir(vim.fn.expand(config.settings.cache_dir), "p")
+	end
 
-  local venv_cache_json = nil
+	local venv_cache_json = nil
 
-  if vim.fn.filereadable(config.settings.cache_file) == 1 then
-    -- if cache file exists and is not empty read it and merge it with the new cache
-    local cached_file = vim.fn.readfile(config.settings.cache_file)
-    if cached_file ~= nil and cached_file[1] ~= nil then
-      local cached_json = vim.fn.json_decode(cached_file[1])
-      local merged_cache = vim.tbl_deep_extend("force", cached_json, venv_cache)
-      venv_cache_json = vim.fn.json_encode(merged_cache)
-    end
-  else
-    venv_cache_json = vim.fn.json_encode(venv_cache)
-  end
-  vim.fn.writefile({ venv_cache_json }, config.settings.cache_file)
+	if vim.fn.filereadable(config.settings.cache_file) == 1 then
+		-- if cache file exists and is not empty read it and merge it with the new cache
+		local cached_file = vim.fn.readfile(config.settings.cache_file)
+		if cached_file ~= nil and cached_file[1] ~= nil then
+			local cached_json = vim.fn.json_decode(cached_file[1])
+			local merged_cache = vim.tbl_deep_extend("force", cached_json, venv_cache)
+			venv_cache_json = vim.fn.json_encode(merged_cache)
+		end
+	else
+		venv_cache_json = vim.fn.json_encode(venv_cache)
+	end
+	vim.fn.writefile({ venv_cache_json }, config.settings.cache_file)
 end
 
 return M


### PR DESCRIPTION
It's well known that there is a whole mess of python dependency managers, of which most are handled by this plugin. However, [PDM](https://pdm.fming.dev/) as a more popular alternative to hatch is missing. This PR should do the trick, however, PDM defaults to "normal" `.venv` directories.  The location given here should be the location of venvs in case of a configuration `venv.in_project = false` for PDM.