### PR TITLE
Fix syntax error in keymap examples for configuration via Lazy

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ return {
     -- auto_refresh = false
   },
 	event = "VeryLazy", -- Optional: needed only if you want to type `:VenvSelect` without a keymapping
-	keys = {{
-    -- Keymap to open VenvSelector to pick a venv.
-		"<leader>vs", "<cmd>:VenvSelect<cr>",
+	keys = {
+        -- Keymap to open VenvSelector to pick a venv.
+		{ "<leader>vs", "<cmd>:VenvSelect<cr>" },
 		-- Keymap to retrieve the venv from a cache (the one previously used for the same project directory).
-		"<leader>vc", "<cmd>:VenvSelectCached<cr>"
-	}}
+		{ "<leader>vc", "<cmd>:VenvSelectCached<cr>" },
+	}
 }
 ```
 
@@ -72,12 +72,12 @@ return {
     -- auto_refresh = false
   }) end,
 	event = "VeryLazy", -- Optional: needed only if you want to type `:VenvSelect` without a keymapping
-	keys = {{
-    -- Keymap to open VenvSelector to pick a venv.
-		"<leader>vs", "<cmd>:VenvSelect<cr>",
+	keys = {
+        -- Keymap to open VenvSelector to pick a venv.
+		{ "<leader>vs", "<cmd>:VenvSelect<cr>" },
 		-- Keymap to retrieve the venv from a cache (the one previously used for the same project directory).
-		"<leader>vc", "<cmd>:VenvSelectCached<cr>"
-	}}
+		{ "<leader>vc", "<cmd>:VenvSelectCached<cr>" },
+	}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,20 +42,20 @@ Easiest way if you use [Lazy.nvim](https://github.com/folke/lazy.nvim) is to use
 
 ```lua
 return {
-	"linux-cultist/venv-selector.nvim",
-	dependencies = { "neovim/nvim-lspconfig", "nvim-telescope/telescope.nvim", "mfussenegger/nvim-dap-python" },
-	opts = {
-    -- Your options go here
-    -- name = "venv",
-    -- auto_refresh = false
-  },
-	event = "VeryLazy", -- Optional: needed only if you want to type `:VenvSelect` without a keymapping
-	keys = {
-        -- Keymap to open VenvSelector to pick a venv.
-		{ "<leader>vs", "<cmd>:VenvSelect<cr>" },
-		-- Keymap to retrieve the venv from a cache (the one previously used for the same project directory).
-		{ "<leader>vc", "<cmd>:VenvSelectCached<cr>" },
-	}
+    "linux-cultist/venv-selector.nvim",
+        dependencies = { "neovim/nvim-lspconfig", "nvim-telescope/telescope.nvim", "mfussenegger/nvim-dap-python" },
+        opts = {
+            -- Your options go here
+                -- name = "venv",
+            -- auto_refresh = false
+        },
+        event = "VeryLazy", -- Optional: needed only if you want to type `:VenvSelect` without a keymapping
+            keys = {
+                -- Keymap to open VenvSelector to pick a venv.
+                { "<leader>vs", "<cmd>:VenvSelect<cr>" },
+                -- Keymap to retrieve the venv from a cache (the one previously used for the same project directory).
+                { "<leader>vc", "<cmd>:VenvSelectCached<cr>" },
+            }
 }
 ```
 
@@ -63,21 +63,21 @@ But if you want, you can also manually call the setup function like this:
 
 ```lua
 return {
-	"linux-cultist/venv-selector.nvim",
-	dependencies = { "neovim/nvim-lspconfig", "nvim-telescope/telescope.nvim", "mfussenegger/nvim-dap-python" },
-	config = function()
-      require("venv-selector").setup({
-    -- Your options go here
-    -- name = "venv",
-    -- auto_refresh = false
-  }) end,
-	event = "VeryLazy", -- Optional: needed only if you want to type `:VenvSelect` without a keymapping
-	keys = {
-        -- Keymap to open VenvSelector to pick a venv.
-		{ "<leader>vs", "<cmd>:VenvSelect<cr>" },
-		-- Keymap to retrieve the venv from a cache (the one previously used for the same project directory).
-		{ "<leader>vc", "<cmd>:VenvSelectCached<cr>" },
-	}
+    "linux-cultist/venv-selector.nvim",
+        dependencies = { "neovim/nvim-lspconfig", "nvim-telescope/telescope.nvim", "mfussenegger/nvim-dap-python" },
+        config = function()
+            require("venv-selector").setup({
+                    -- Your options go here
+                    -- name = "venv",
+                    -- auto_refresh = false
+                    }) end,
+        event = "VeryLazy", -- Optional: needed only if you want to type `:VenvSelect` without a keymapping
+            keys = {
+                -- Keymap to open VenvSelector to pick a venv.
+                { "<leader>vs", "<cmd>:VenvSelect<cr>" },
+                -- Keymap to retrieve the venv from a cache (the one previously used for the same project directory).
+                { "<leader>vc", "<cmd>:VenvSelectCached<cr>" },
+            }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,16 +46,16 @@ return {
         dependencies = { "neovim/nvim-lspconfig", "nvim-telescope/telescope.nvim", "mfussenegger/nvim-dap-python" },
         opts = {
             -- Your options go here
-                -- name = "venv",
+            -- name = "venv",
             -- auto_refresh = false
         },
         event = "VeryLazy", -- Optional: needed only if you want to type `:VenvSelect` without a keymapping
-            keys = {
-                -- Keymap to open VenvSelector to pick a venv.
-                { "<leader>vs", "<cmd>:VenvSelect<cr>" },
-                -- Keymap to retrieve the venv from a cache (the one previously used for the same project directory).
-                { "<leader>vc", "<cmd>:VenvSelectCached<cr>" },
-            }
+        keys = {
+            -- Keymap to open VenvSelector to pick a venv.
+            { "<leader>vs", "<cmd>:VenvSelect<cr>" },
+            -- Keymap to retrieve the venv from a cache (the one previously used for the same project directory).
+            { "<leader>vc", "<cmd>:VenvSelectCached<cr>" },
+        }
 }
 ```
 
@@ -67,18 +67,18 @@ return {
         dependencies = { "neovim/nvim-lspconfig", "nvim-telescope/telescope.nvim", "mfussenegger/nvim-dap-python" },
         config = function()
             require("venv-selector").setup({
-                    -- Your options go here
-                    -- name = "venv",
-                    -- auto_refresh = false
+                -- Your options go here
+                -- name = "venv",
+                -- auto_refresh = false
             })
         end,
         event = "VeryLazy", -- Optional: needed only if you want to type `:VenvSelect` without a keymapping
-            keys = {
-                -- Keymap to open VenvSelector to pick a venv.
-                { "<leader>vs", "<cmd>:VenvSelect<cr>" },
-                -- Keymap to retrieve the venv from a cache (the one previously used for the same project directory).
-                { "<leader>vc", "<cmd>:VenvSelectCached<cr>" },
-            }
+        keys = {
+            -- Keymap to open VenvSelector to pick a venv.
+            { "<leader>vs", "<cmd>:VenvSelect<cr>" },
+            -- Keymap to retrieve the venv from a cache (the one previously used for the same project directory).
+            { "<leader>vc", "<cmd>:VenvSelectCached<cr>" },
+        }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ return {
                     -- Your options go here
                     -- name = "venv",
                     -- auto_refresh = false
-                    }) end,
+            })
+        end,
         event = "VeryLazy", -- Optional: needed only if you want to type `:VenvSelect` without a keymapping
             keys = {
                 -- Keymap to open VenvSelector to pick a venv.


### PR DESCRIPTION
The Lua table formatting in the Lazy configuration examples is wrong. This PR corrects the examples.