### PR TITLE
Remove superfluous colons in key binding examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,19 +43,19 @@ Easiest way if you use [Lazy.nvim](https://github.com/folke/lazy.nvim) is to use
 ```lua
 return {
     "linux-cultist/venv-selector.nvim",
-        dependencies = { "neovim/nvim-lspconfig", "nvim-telescope/telescope.nvim", "mfussenegger/nvim-dap-python" },
-        opts = {
-            -- Your options go here
-            -- name = "venv",
-            -- auto_refresh = false
-        },
-        event = "VeryLazy", -- Optional: needed only if you want to type `:VenvSelect` without a keymapping
-        keys = {
-            -- Keymap to open VenvSelector to pick a venv.
-            { "<leader>vs", "<cmd>:VenvSelect<cr>" },
-            -- Keymap to retrieve the venv from a cache (the one previously used for the same project directory).
-            { "<leader>vc", "<cmd>:VenvSelectCached<cr>" },
-        }
+    dependencies = { "neovim/nvim-lspconfig", "nvim-telescope/telescope.nvim", "mfussenegger/nvim-dap-python" },
+    opts = {
+        -- Your options go here
+        -- name = "venv",
+        -- auto_refresh = false
+    },
+    event = "VeryLazy", -- Optional: needed only if you want to type `:VenvSelect` without a keymapping
+    keys = {
+        -- Keymap to open VenvSelector to pick a venv.
+        { "<leader>vs", "<cmd>:VenvSelect<cr>" },
+        -- Keymap to retrieve the venv from a cache (the one previously used for the same project directory).
+        { "<leader>vc", "<cmd>:VenvSelectCached<cr>" },
+    }
 }
 ```
 
@@ -64,21 +64,21 @@ But if you want, you can also manually call the setup function like this:
 ```lua
 return {
     "linux-cultist/venv-selector.nvim",
-        dependencies = { "neovim/nvim-lspconfig", "nvim-telescope/telescope.nvim", "mfussenegger/nvim-dap-python" },
-        config = function()
-            require("venv-selector").setup({
-                -- Your options go here
-                -- name = "venv",
-                -- auto_refresh = false
-            })
-        end,
-        event = "VeryLazy", -- Optional: needed only if you want to type `:VenvSelect` without a keymapping
-        keys = {
-            -- Keymap to open VenvSelector to pick a venv.
-            { "<leader>vs", "<cmd>:VenvSelect<cr>" },
-            -- Keymap to retrieve the venv from a cache (the one previously used for the same project directory).
-            { "<leader>vc", "<cmd>:VenvSelectCached<cr>" },
-        }
+    dependencies = { "neovim/nvim-lspconfig", "nvim-telescope/telescope.nvim", "mfussenegger/nvim-dap-python" },
+    config = function()
+        require("venv-selector").setup({
+            -- Your options go here
+            -- name = "venv",
+            -- auto_refresh = false
+        })
+    end,
+    event = "VeryLazy", -- Optional: needed only if you want to type `:VenvSelect` without a keymapping
+    keys = {
+        -- Keymap to open VenvSelector to pick a venv.
+        { "<leader>vs", "<cmd>:VenvSelect<cr>" },
+        -- Keymap to retrieve the venv from a cache (the one previously used for the same project directory).
+        { "<leader>vc", "<cmd>:VenvSelectCached<cr>" },
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ return {
     event = "VeryLazy", -- Optional: needed only if you want to type `:VenvSelect` without a keymapping
     keys = {
         -- Keymap to open VenvSelector to pick a venv.
-        { "<leader>vs", "<cmd>:VenvSelect<cr>" },
+        { "<leader>vs", "<cmd>VenvSelect<cr>" },
         -- Keymap to retrieve the venv from a cache (the one previously used for the same project directory).
-        { "<leader>vc", "<cmd>:VenvSelectCached<cr>" },
+        { "<leader>vc", "<cmd>VenvSelectCached<cr>" },
     }
 }
 ```
@@ -75,9 +75,9 @@ return {
     event = "VeryLazy", -- Optional: needed only if you want to type `:VenvSelect` without a keymapping
     keys = {
         -- Keymap to open VenvSelector to pick a venv.
-        { "<leader>vs", "<cmd>:VenvSelect<cr>" },
+        { "<leader>vs", "<cmd>VenvSelect<cr>" },
         -- Keymap to retrieve the venv from a cache (the one previously used for the same project directory).
-        { "<leader>vc", "<cmd>:VenvSelectCached<cr>" },
+        { "<leader>vc", "<cmd>VenvSelectCached<cr>" },
     }
 }
 ```


### PR DESCRIPTION
A few more pretty pedantic updates to the README.

The example key binding commands starts with `<cmd>:` which is a pleonasm since `cmd` is a synonym for `:` :-)

This PR removes the `:` and also fixes an overlooked over-indentation from my last PR.