### PR TITLE
Replace pyright hook

### DIFF
--- a/lua/venv-selector/hooks.lua
+++ b/lua/venv-selector/hooks.lua
@@ -21,18 +21,11 @@ end
 --- @alias VenvChangedHook fun(venv_path: string, venv_python: string): nil
 --- @type VenvChangedHook
 function M.pyright_hook(_, venv_python)
-  M.execute_for_client("pyright", function(pyright)
-    local utils = require("venv-selector.utils")
-    local settings = vim.deepcopy(pyright.config.settings)
-    lspconfig.pyright.setup({
-      settings = settings,
-      before_init = function(_, c)
-        c.settings.python.pythonPath = venv_python
-        utils.dbg("Pyright settings:")
-        utils.dbg(c.settings)
-      end,
-    })
-  end)
+  local clients = vim.lsp.get_active_clients({ name = "pyright" })
+  for _, client in ipairs(clients) do
+    client.config.settings = vim.tbl_deep_extend("force", client.config.settings, { python = { pythonPath = venv_python } })
+    client.notify("workspace/didChangeConfiguration", { settings = nil })
+  end
 end
 
 --- @type VenvChangedHook


### PR DESCRIPTION
The current pyright hook resets all settings passed in to lspconfig except for the `settings` value. This is documented in #58. 

This PR essentially reverts commit `a37ea94`. The main difference is that all active pyright clients are updated instead of the first one. This snippet is heavily inspired by https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig/server_configurations/pyright.lua.