### PR TITLE
Set $CONDA_PREFIX instead of $VIRTUAL_ENV for conda environments

### DIFF
--- a/lua/venv-selector/venv.lua
+++ b/lua/venv-selector/venv.lua
@@ -112,7 +112,21 @@ function M.set_venv_and_system_paths(venv_row)
   M.current_bin_path = new_bin_path
 
   -- Set VIRTUAL_ENV
-  vim.fn.setenv('VIRTUAL_ENV', venv_path)
+  -- Set CONDA_PREFIX instead if we are on Windows and a conda environment is activated
+  if vim.fn.has("win32") then
+    local venv_path_std = string.gsub(venv_path, '/', '\\')
+    local conda_base_path_std = string.gsub(config.settings.anaconda_base_path, '/', '\\')
+    local conda_envs_path_std = string.gsub(config.settings.anaconda_envs_path, '/', '\\')
+    local is_conda_base = string.find(venv_path_std, conda_base_path_std)
+    local is_conda_env = string.find(venv_path, conda_envs_path_std)
+    if is_conda_base == 1 or is_conda_env == 1 then
+      vim.fn.setenv('CONDA_PREFIX', venv_path)
+    else
+      vim.fn.setenv('VIRTUAL_ENV', venv_path)
+    end
+  else
+    vim.fn.setenv('VIRTUAL_ENV', venv_path)
+  end
 
   M.current_python_path = venv_python
   M.current_venv = venv_path


### PR DESCRIPTION
This PR fixes a bug for Windows users with conda environments.

The plugin originally sets the environment variable `$VIRTUAL_ENV` when activating virtual environments. This variable is used by `nvim-dap-python` to set the Python interpreter path for debugging. However, the relative path of python interpreter for Windows conda environments is `[venv]\python.exe`, which is different from other types virtual environments, whose relative path is `[venv]\Scripts\python.exe`. Thus setting `$VIRTUAL_ENV` leads to a wrong python path (namely `[venv]\Scripts\python.exe`) for `nvim-dap-python`. This can also be seen from the code of `nvim-dap-python` plugin:

```
local get_python_path = function()
  local venv_path = os.getenv('VIRTUAL_ENV')
  if venv_path then
    if is_windows() then
      return venv_path .. '\\Scripts\\python.exe'
    end
    return venv_path .. '/bin/python'
  end

  venv_path = os.getenv("CONDA_PREFIX")
  if venv_path then
    if is_windows() then
      return venv_path .. '\\python.exe'
    end
    return venv_path .. '/bin/python'
  end

  ...
end
```

Therefore, it seems necessary to set `$CONDA_PREFIX` instead of `$VIRTUAL_ENV` when activating conda environments on Windows.

This PR fixes the above issue. It does not introduce any changes to non-Windows users.