### PR TITLE
Edited the logic for setting CONDA_PREFIX to also work for Linux and Mac for conda users, not just Windows users

### DIFF
--- a/lua/venv-selector/venv.lua
+++ b/lua/venv-selector/venv.lua
@@ -112,20 +112,23 @@ function M.set_venv_and_system_paths(venv_row)
   M.current_bin_path = new_bin_path
 
   -- Set VIRTUAL_ENV
-  -- Set CONDA_PREFIX instead if we are on Windows and a conda environment is activated
-  if vim.fn.has("win32") then
-    local venv_path_std = string.gsub(venv_path, '/', '\\')
-    local conda_base_path_std = string.gsub(config.settings.anaconda_base_path, '/', '\\')
-    local conda_envs_path_std = string.gsub(config.settings.anaconda_envs_path, '/', '\\')
-    local is_conda_base = string.find(venv_path_std, conda_base_path_std)
-    local is_conda_env = string.find(venv_path, conda_envs_path_std)
-    if is_conda_base == 1 or is_conda_env == 1 then
-      vim.fn.setenv('CONDA_PREFIX', venv_path)
-    else
-      vim.fn.setenv('VIRTUAL_ENV', venv_path)
-    end
+  -- TODO Test on Windows if we can get rid of new local variable venv_path_std, and just mutate venv_path directly to replace forward slash
+  local venv_path_std = venv_path
+  local conda_base_path_std = config.settings.anaconda_base_path
+  local conda_envs_path_std = config.settings.anaconda_envs_path
+  -- Replace forward slash if we are on Windows
+  if vim.fn.has 'win32' then
+    venv_path_std = string.gsub(venv_path_std, '/', '\\')
+    conda_base_path_std = string.gsub(conda_base_path_std, '/', '\\')
+    conda_envs_path_std = string.gsub(conda_envs_path_std, '/', '\\')
+  end
+  -- Set CONDA_PREFIX instead if a conda environment is activated. This should work on Linux, Windows, or Mac, and is useful for conda users.
+  local is_conda_base = string.find(venv_path_std, conda_base_path_std)
+  local is_conda_env = string.find(venv_path_std, conda_envs_path_std)
+  if is_conda_base == 1 or is_conda_env == 1 then
+    vim.fn.setenv('CONDA_PREFIX', venv_path_std)
   else
-    vim.fn.setenv('VIRTUAL_ENV', venv_path)
+    vim.fn.setenv('VIRTUAL_ENV', venv_path_std)
   end
 
   M.current_python_path = venv_python


### PR DESCRIPTION
With this change, CONDA_PREFIX is also set for Linux and Mac (if conda environment is activated), not just windows users.

Prior to this change, opening a terminal, one would see that $CONDA_PREFIX was not set because it was only being set if "vim.fn.has 'win32'" was true.