### PR TITLE
Enhance hooks and ensure compatibility with nightly build

### DIFF
--- a/lua/venv-selector/hooks.lua
+++ b/lua/venv-selector/hooks.lua
@@ -3,19 +3,6 @@ local M = {}
 --- @alias NvimLspClient table
 --- @alias LspClientCallback fun(client: NvimLspClient): nil
 --- @type fun(name: string, callback: LspClientCallback): nil
-function M.execute_for_clients(name, callback)
-  local dbg = require('venv-selector.utils').dbg
-  -- get_active_clients deprecated in neovim v0.10
-  local clients = (vim.lsp.get_clients or vim.lsp.get_active_clients) { name = name }
-
-  if not next(clients) then
-    dbg('No client named: ' .. name .. ' found')
-  else
-    vim.tbl_map(callback, clients)
-  end
-end
-
---- @type fun(name: string, callback: LspClientCallback): nil
 function M.execute_for_client(name, callback)
   local dbg = require('venv-selector.utils').dbg
   -- get_active_clients deprecated in neovim v0.10
@@ -31,7 +18,7 @@ end
 --- @alias VenvChangedHook fun(venv_path: string, venv_python: string): nil
 --- @type VenvChangedHook
 function M.pyright_hook(_, venv_python)
-  M.execute_for_clients('pyright', function(client)
+  M.execute_for_client('pyright', function(client)
     if client.settings then
       client.settings = vim.tbl_deep_extend('force', client.settings, { python = { pythonPath = venv_python } })
     else
@@ -44,7 +31,7 @@ end
 
 --- @type VenvChangedHook
 function M.pylance_hook(_, venv_python)
-  M.execute_for_clients('pylance', function(client)
+  M.execute_for_client('pylance', function(client)
     if client.settings then
       client.settings = vim.tbl_deep_extend('force', client.settings, { python = { pythonPath = venv_python } })
     else

--- a/lua/venv-selector/hooks.lua
+++ b/lua/venv-selector/hooks.lua
@@ -32,8 +32,12 @@ end
 --- @type VenvChangedHook
 function M.pyright_hook(_, venv_python)
   M.execute_for_clients('pyright', function(client)
-    client.config.settings =
-      vim.tbl_deep_extend('force', client.config.settings, { python = { pythonPath = venv_python } })
+    if client.settings then
+      client.settings = vim.tbl_deep_extend('force', client.settings, { python = { pythonPath = venv_python } })
+    else
+      client.config.settings =
+        vim.tbl_deep_extend('force', client.config.settings, { python = { pythonPath = venv_python } })
+    end
     client.notify('workspace/didChangeConfiguration', { settings = nil })
   end)
 end
@@ -41,8 +45,12 @@ end
 --- @type VenvChangedHook
 function M.pylance_hook(_, venv_python)
   M.execute_for_clients('pylance', function(client)
-    client.config.settings =
-      vim.tbl_deep_extend('force', client.config.settings, { python = { pythonPath = venv_python } })
+    if client.settings then
+      client.settings = vim.tbl_deep_extend('force', client.settings, { python = { pythonPath = venv_python } })
+    else
+      client.config.settings =
+        vim.tbl_deep_extend('force', client.config.settings, { python = { pythonPath = venv_python } })
+    end
     client.notify('workspace/didChangeConfiguration', { settings = nil })
   end)
 end
@@ -50,7 +58,7 @@ end
 --- @type VenvChangedHook
 function M.pylsp_hook(_, venv_python)
   M.execute_for_client('pylsp', function(client)
-    local settings = vim.tbl_deep_extend('force', client.config.settings, {
+    local settings = vim.tbl_deep_extend('force', (client.settings or client.config.settings), {
       pylsp = {
         plugins = {
           jedi = {


### PR DESCRIPTION
Summary of changes:

1. Simplify pylsp hook and use `workspace/didChangeConfiguration` instead of the `setup` function in pylsp hook.
2. pyright and pylance hook no longer work on neovim nightly due to https://github.com/neovim/neovim/commit/9f8c96240dc0318bd92a646966917e8fe0641144. (`client.config.settings` is readonly on neovim nightly)
3. `execut_for_clients` and `execute_for_client` do the same thing.
  `vim.lsp.get_active_clients({name="name"})` always return one client, even thought it attaches onto many buffer. So, there is no need to use `vim.tbl_map`.