### PR TITLE
Fix log call

### DIFF
--- a/lua/venv-selector/workspace.lua
+++ b/lua/venv-selector/workspace.lua
@@ -1,3 +1,5 @@
+local log = require("venv-selector.logger")
+
 M = {}
 
 function M.list_folders()


### PR DESCRIPTION
`log` doesn't exist in the global namespace, so we get a `attempt to index global 'log' (a nil value)` error. Add a reference to the logger module to avoid this