### PR TITLE
Also search for hidden folders in the current directory on default

### DIFF
--- a/lua/venv-selector/config.lua
+++ b/lua/venv-selector/config.lua
@@ -33,7 +33,7 @@ function M.get_default_searches()
                     command = "$FD /bin/python$ ~/.local/share/pipx/venvs --full-path --color never -E /proc",
                 },
                 cwd = {
-                    command = "$FD /bin/python$ $CWD --full-path --color never -E /proc -I -a -L",
+                    command = "$FD /bin/python$ $CWD --full-path --color never -E /proc -HI -a -L",
                 },
                 workspace = {
                     command = "$FD /bin/python$ $WORKSPACE_PATH --full-path --color never -E /proc -HI -a -L",
@@ -70,7 +70,7 @@ function M.get_default_searches()
                     command = "$FD /bin/python$ ~/.local/share/pipx/venvs --full-path --color never -E /proc",
                 },
                 cwd = {
-                    command = "$FD /bin/python$ $CWD --full-path --color never -E /proc -I -a -L",
+                    command = "$FD /bin/python$ $CWD --full-path --color never -E /proc -HI -a -L",
                 },
                 workspace = {
                     command = "$FD /bin/python$ $WORKSPACE_PATH --full-path --color never -E /proc -HI -a -L",
@@ -104,7 +104,7 @@ function M.get_default_searches()
                     command = "fd Scripts\\\\python.exe $HOME/pipx/venvs --full-path -a --color never"
                 },
                 cwd = {
-                    command = "$FD Scripts\\\\python.exe$ $CWD --full-path --color never -I -a -L",
+                    command = "$FD Scripts\\\\python.exe$ $CWD --full-path --color never -HI -a -L",
                 },
                 workspace = {
                     command = "$FD Scripts\\\\python.exe$ $WORKSPACE_PATH --full-path --color never -HI -a -L",

--- a/lua/venv-selector/config.lua
+++ b/lua/venv-selector/config.lua
@@ -10,73 +10,73 @@ function M.get_default_searches()
         ['Linux'] = function()
             return {
                 virtualenvs = {
-                    command = "$FD python$ ~/.virtualenvs --color never -E /proc"
+                    command = "$FD 'python$' ~/.virtualenvs --color never -E /proc"
                 },
                 hatch = {
-                    command = "$FD python$ ~/.local/share/hatch --color never -E '*-build*' -E /proc"
+                    command = "$FD 'python$' ~/.local/share/hatch --color never -E '*-build*' -E /proc"
                 },
                 poetry = {
-                    command = "$FD /bin/python$ ~/.cache/pypoetry/virtualenvs --full-path"
+                    command = "$FD '/bin/python$' ~/.cache/pypoetry/virtualenvs --full-path"
                 },
                 pyenv = {
                     command = "$FD 'versions/([0-9.]+)/bin/python$' ~/.pyenv/versions --full-path --color never -E /proc"
                 },
                 anaconda_envs = {
-                    command = "$FD bin/python$ ~/.conda/envs --full-path --color never -E /proc",
+                    command = "$FD 'bin/python$' ~/.conda/envs --full-path --color never -E /proc",
                     type = "anaconda"
                 },
                 anaconda_base = {
-                    command = "$FD /python$ /opt/anaconda/bin --full-path --color never -E /proc",
+                    command = "$FD '/python$' /opt/anaconda/bin --full-path --color never -E /proc",
                     type = "anaconda"
                 },
                 pipx = {
-                    command = "$FD /bin/python$ ~/.local/share/pipx/venvs --full-path --color never -E /proc",
+                    command = "$FD '/bin/python$' ~/.local/share/pipx/venvs --full-path --color never -E /proc",
                 },
                 cwd = {
-                    command = "$FD /bin/python$ $CWD --full-path --color never -E /proc -HI -a -L",
+                    command = "$FD '/bin/python$' $CWD --full-path --color never -E /proc -HI -a -L",
                 },
                 workspace = {
-                    command = "$FD /bin/python$ $WORKSPACE_PATH --full-path --color never -E /proc -HI -a -L",
+                    command = "$FD '/bin/python$' $WORKSPACE_PATH --full-path --color never -E /proc -HI -a -L",
                 },
                 file = {
-                    command = "$FD /bin/python$ $FILE_DIR --full-path --color never -E /proc -HI -a -L",
+                    command = "$FD '/bin/python$' $FILE_DIR --full-path --color never -E /proc -HI -a -L",
                 }
             }
         end,
         ['Darwin'] = function()
             return {
                 virtualenvs = {
-                    command = "$FD python$ ~/.virtualenvs --color never -E /proc"
+                    command = "$FD 'python$' ~/.virtualenvs --color never -E /proc"
                 },
                 hatch = {
                     command =
-                    "$FD python$ ~/Library/Application/Support/hatch/env/virtual --color never -E '*-build*' -E /proc"
+                    "$FD 'python$' ~/Library/Application/Support/hatch/env/virtual --color never -E '*-build*' -E /proc"
                 },
                 poetry = {
-                    command = "$FD /bin/python$ ~/Library/Caches/pypoetry/virtualenvs --full-path"
+                    command = "$FD '/bin/python$' ~/Library/Caches/pypoetry/virtualenvs --full-path"
                 },
                 pyenv = {
                     command = "$FD 'versions/([0-9.]+)/bin/python$' ~/.pyenv/versions --full-path --color never -E /proc"
                 },
                 anaconda_envs = {
-                    command = "$FD bin/python$ ~/.conda/envs --full-path --color never -E /proc",
+                    command = "$FD 'bin/python$' ~/.conda/envs --full-path --color never -E /proc",
                     type = "anaconda"
                 },
                 anaconda_base = {
-                    command = "$FD /python$ /opt/anaconda/bin --full-path --color never -E /proc",
+                    command = "$FD '/python$' /opt/anaconda/bin --full-path --color never -E /proc",
                     type = "anaconda"
                 },
                 pipx = {
-                    command = "$FD /bin/python$ ~/.local/share/pipx/venvs --full-path --color never -E /proc",
+                    command = "$FD '/bin/python$' ~/.local/share/pipx/venvs --full-path --color never -E /proc",
                 },
                 cwd = {
-                    command = "$FD /bin/python$ $CWD --full-path --color never -E /proc -HI -a -L",
+                    command = "$FD '/bin/python$' $CWD --full-path --color never -E /proc -HI -a -L",
                 },
                 workspace = {
-                    command = "$FD /bin/python$ $WORKSPACE_PATH --full-path --color never -E /proc -HI -a -L",
+                    command = "$FD '/bin/python$' $WORKSPACE_PATH --full-path --color never -E /proc -HI -a -L",
                 },
                 file = {
-                    command = "$FD /bin/python$ $FILE_DIR --full-path --color never -E /proc -HI -a -L",
+                    command = "$FD '/bin/python$' $FILE_DIR --full-path --color never -E /proc -HI -a -L",
                 }
             }
         end,


### PR DESCRIPTION
The current defaults only search for the Python binary in non-hidden directories when searching in the current working directory. It ignores the folders like '.venv' and '.env', commonly used patterns to name a virtual environment when created using the command `python3 -m venv .venv`.