### PR TITLE
fix: select venv instead of open bin/python file by <cr> in normal mode

### DIFF
--- a/lua/venv-selector/gui.lua
+++ b/lua/venv-selector/gui.lua
@@ -232,7 +232,7 @@ function M.open(in_progress)
         sorting_strategy = "ascending",
         sorter = M.get_sorter()(),
         attach_mappings = function(bufnr, map)
-            map("i", "<cr>", function()
+            map({ "i", "n" }, "<cr>", function()
                 local selected_entry = actions_state.get_selected_entry()
                 local activated = false
                 if selected_entry ~= nil then


### PR DESCRIPTION
Fixes [#144](https://github.com/linux-cultist/venv-selector.nvim/issues/144).

Just a small fix for people who use telescope's normal mode.