### PR TITLE
fix: show search results when using windows with git bash

### DIFF
--- a/lua/venv-selector/search.lua
+++ b/lua/venv-selector/search.lua
@@ -119,7 +119,15 @@ local function run_search(opts)
         local job = path.expand(search.execute_command)
         log.debug("Starting '" .. job_name .. "': '" .. job .. "'")
         M.search_in_progress = true
-        local job_id = vim.fn.jobstart(job, {
+
+        local cmd
+        if vim.loop.os_uname().sysname == "Windows_NT" then
+          cmd = { vim.o.shell, vim.o.shellcmdflag, job }
+        else
+          cmd = job
+        end
+
+        local job_id = vim.fn.jobstart(cmd, {
             stdout_buffered = true,
             stderr_buffered = true,
             on_stdout = on_event,


### PR DESCRIPTION
Hello,

I was unable to find a virtual environment on Windows (my configured shell is Git Bash). I'm unsure why the original version didn't work, as the documentation for `vim.fn.jobstart` indicates that the configured shell and shell flag are respected when the command is a string, not a list. Is it possible that in Lua, the argument is always interpreted as a list?