### PR TITLE
fix(search): no results when using some shell on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - Supports callbacks to further filter or rename telescope results as they are found.
 - Supports using any program to find virtual environments (`fd`, `find`, `ls`, `dir` etc)
 - Supports running any interactive command to populate the telescope viewer:
-  - `:VenvSelect fd 'python$' . --full-path -IH -a`
+  - `:VenvSelect fd python$ . --full-path -IH -a`
 
 - Support [Pyright](https://github.com/microsoft/pyright), [Pylance](https://github.com/microsoft/pylance-release) and [Pylsp](https://github.com/python-lsp/python-lsp-server) lsp servers with ability to config hooks for others.
 - Virtual environments are remembered for each specific working directory and automatically activated the next time.
@@ -117,7 +117,7 @@ The configuration looks like this:
         settings = {
           search = {
             my_venvs = {
-              command = "fd python$ ~/Code",
+              command = { "fd", "python$", "~/Code" },
             },
           },
         },
@@ -143,21 +143,15 @@ You can add multiple searches as well:
         settings = {
           search = {
             find_code_venvs = {
-              command = "fd /bin/python$ ~/Code --full-path",
+              command = { "fd", "/bin/python$", "~/Code", "--full-path" },
             },
             find_programming_venvs = {
-              command = "fd /bin/python$ ~/Programming/Python --full-path -IHL -E /proc",
+              command = { "fd", "/bin/python$", "~/Programming/Python", "--full-path", "-IHL", "-E", "/proc" },
             },
           },
         },
       }
 ```
-
-Some notes about using quotes or not around the regexp: 
-
-- For `fish` shell, you need to put the regexp in quotes: `'/bin/python$'`.
-- For `zsh` and `bash`, they are optional.
-- On `Windows` using `powershell`, quotes are not working.
 
 ### Special note about anaconda/miniconda searches
 
@@ -170,7 +164,7 @@ Even if its a miniconda environment, the type needs to be anaconda since the sam
         settings = {
           search = {
             anaconda_base = {
-                command = "fd /python$ /opt/anaconda/bin --full-path --color never -E /proc",
+                command = { "fd", "/python$", "/opt/anaconda/bin", "--full-path", "--color", "never", "-E", "/proc" },
                 type = "anaconda"
             },
           },
@@ -204,7 +198,7 @@ Here is an example of *replacing* the default cwd search with one that **doesnt*
 settings = {
   search = {
     cwd = {
-      command = "fd '/bin/python$' $CWD --full-path --color never -E /proc -I -a -L",
+      command = { "fd", "/bin/python$", "$CWD", "--full-path", "--color", "never", "-E", "/proc", "-I", "-a", "-L" },
     },
   },
 }
@@ -219,7 +213,7 @@ settings = {
   search = {
     cwd = false, -- setting this to false disables the default cwd search
     my_search = {
-      command = "fd /bin/python$ ~/Code --full-path -a -L" -- read up on the fd flags so it searches what you need
+      command = { "fd", "/bin/python$", "~/Code", "--full-path", "-a", "-L" }, -- read up on the fd flags so it searches what you need
     }
   },
 }
@@ -255,7 +249,7 @@ If you want to **override** one of the default searches, create a search with th
 settings = {
   search = {
     workspace = {
-      command = "fd /bin/python$ $WORKSPACE_PATH --full-path --color never -E /proc -unrestricted",
+      command = { "fd", "/bin/python$", "$WORKSPACE_PATH", "--full-path", "--color", "never", "-E", "/proc", "--unrestricted" },
     }
   }
 }
@@ -309,7 +303,7 @@ Maybe you dont want to see the entire full path to python in the telescope viewe
 
           search = {
             my_venvs = {
-              command = "fd python$ ~/Code", -- Sample command, need to be changed for your own venvs
+              command = { "fd", "python$", "~/Code" }, -- Sample command, need to be changed for your own venvs
               
               -- If you put the callback here, its only called for your "my_venvs" search
               on_telescope_result_callback = shorter_name 

--- a/lua/venv-selector/config.lua
+++ b/lua/venv-selector/config.lua
@@ -6,98 +6,99 @@ local M = {}
 M.user_settings = {}
 
 function M.get_default_searches()
+    -- stylua: ignore
     local systems = {
         ["Linux"] = function()
             return {
                 virtualenvs = {
-                    command = "$FD 'python$' ~/.virtualenvs --color never",
+                    command = { "$FD", "python$", "~/.virtualenvs", "--color", "never" },
                 },
                 hatch = {
-                    command = "$FD 'python$' ~/.local/share/hatch --color never -E '*-build*'",
+                    command = { "$FD", "python$", "~/.local/share/hatch", "--color", "never", "-E", "*-build*" },
                 },
                 poetry = {
-                    command = "$FD '/bin/python$' ~/.cache/pypoetry/virtualenvs --full-path",
+                    command = { "$FD", "/bin/python$", "~/.cache/pypoetry/virtualenvs", "--full-path" },
                 },
                 pyenv = {
-                    command = "$FD '/bin/python$' ~/.pyenv/versions --full-path --color never -E pkgs/ -E envs/ -L",
+                    command = { "$FD", "/bin/python$", "~/.pyenv/versions", "--full-path", "--color", "never", "-E", "pkgs/", "-E", "envs/", "-L" },
                 },
                 pipenv = {
-                    command = "$FD '/bin/python$' ~/.local/share/virtualenvs --full-path --color never",
+                    command = { "$FD", "/bin/python$", "~/.local/share/virtualenvs", "--full-path", "--color", "never" },
                 },
                 anaconda_envs = {
-                    command = "$FD 'bin/python$' ~/.conda/envs --full-path --color never",
+                    command = { "$FD", "bin/python$", "~/.conda/envs", "--full-path", "--color", "never" },
                     type = "anaconda",
                 },
                 anaconda_base = {
-                    command = "$FD '/python$' /opt/anaconda/bin --full-path --color never",
+                    command = { "$FD", "/python$", "/opt/anaconda/bin", "--full-path", "--color", "never" },
                     type = "anaconda",
                 },
                 miniconda_envs = {
-                    command = "$FD 'bin/python$' ~/miniconda3/envs --full-path --color never",
+                    command = { "$FD", "bin/python$", "~/miniconda3/envs", "--full-path", "--color", "never" },
                     type = "anaconda",
                 },
                 miniconda_base = {
-                    command = "$FD '/python$' ~/miniconda3/bin --full-path --color never",
+                    command = { "$FD", "/python$", "~/miniconda3/bin", "--full-path", "--color", "never" },
                     type = "anaconda",
                 },
                 pipx = {
-                    command = "$FD '/bin/python$' ~/.local/share/pipx/venvs ~/.local/pipx/venvs --full-path --color never",
+                    command = { "$FD", "/bin/python$", "~/.local/share/pipx/venvs", "~/.local/pipx/venvs", "--full-path", "--color", "never" },
                 },
                 cwd = {
-                    command = "$FD '/bin/python$' $CWD --full-path --color never -HI -a -L -E /proc -E .git/ -E .wine/ -E .steam/ -E Steam/ -E site-packages/",
+                    command = { "$FD", "/bin/python$", "$CWD", "--full-path", "--color", "never", "-HI", "-a", "-L", "-E", "/proc", "-E", ".git/", "-E", ".wine/", "-E", ".steam/", "-E", "Steam/", "-E", "site-packages/" },
                 },
                 workspace = {
-                    command = "$FD '/bin/python$' $WORKSPACE_PATH --full-path --color never -E /proc -HI -a -L",
+                    command = { "$FD", "/bin/python$", "$WORKSPACE_PATH", "--full-path", "--color", "never", "-E", "/proc", "-HI", "-a", "-L" },
                 },
                 file = {
-                    command = "$FD '/bin/python$' $FILE_DIR --full-path --color never -E /proc -HI -a -L",
+                    command = { "$FD", "/bin/python$", "$FILE_DIR", "--full-path", "--color", "never", "-E", "/proc", "-HI", "-a", "-L" },
                 },
             }
         end,
         ["Darwin"] = function()
             return {
                 virtualenvs = {
-                    command = "$FD 'python$' ~/.virtualenvs --color never",
+                    command = { "$FD", "python$", "~/.virtualenvs", "--color", "never" },
                 },
                 hatch = {
-                    command = "$FD 'python$' ~/Library/Application\\\\ Support/hatch/env/virtual --color never -E '*-build*'",
+                    command = { "$FD", "python$", "~/Library/Application\\\\ Support/hatch/env/virtual", "--color", "never", "-E", "*-build*" },
                 },
                 poetry = {
-                    command = "$FD '/bin/python$' ~/Library/Caches/pypoetry/virtualenvs --full-path",
+                    command = { "$FD", "/bin/python$", "~/Library/Caches/pypoetry/virtualenvs", "--full-path" },
                 },
                 pyenv = {
-                    command = "$FD '/bin/python$' ~/.pyenv/versions --full-path --color never -E pkgs/ -E envs/ -L",
+                    command = { "$FD", "/bin/python$", "~/.pyenv/versions", "--full-path", "--color", "never", "-E", "pkgs/", "-E", "envs/", "-L" },
                 },
                 pipenv = {
-                    command = "$FD '/bin/python$' ~/.local/share/virtualenvs --full-path --color never",
+                    command = { "$FD", "/bin/python$", "~/.local/share/virtualenvs", "--full-path", "--color", "never" },
                 },
                 anaconda_envs = {
-                    command = "$FD 'bin/python$' ~/.conda/envs --full-path --color never",
+                    command = { "$FD", "bin/python$", "~/.conda/envs", "--full-path", "--color", "never" },
                     type = "anaconda",
                 },
                 anaconda_base = {
-                    command = "$FD '/python$' /opt/anaconda/bin --full-path --color never",
+                    command = { "$FD", "/python$", "/opt/anaconda/bin", "--full-path", "--color", "never" },
                     type = "anaconda",
                 },
                 miniconda_envs = {
-                    command = "$FD 'bin/python$' ~/miniconda3/envs --full-path --color never",
+                    command = { "$FD", "bin/python$", "~/miniconda3/envs", "--full-path", "--color", "never" },
                     type = "anaconda",
                 },
                 miniconda_base = {
-                    command = "$FD '/python$' ~/miniconda3/bin --full-path --color never",
+                    command = { "$FD", "/python$", "~/miniconda3/bin", "--full-path", "--color", "never" },
                     type = "anaconda",
                 },
                 pipx = {
-                    command = "$FD '/bin/python$' ~/.local/share/pipx/venvs ~/.local/pipx/venvs --full-path --color never",
+                    command = { "$FD", "/bin/python$", "~/.local/share/pipx/venvs", "~/.local/pipx/venvs", "--full-path", "--color", "never" },
                 },
                 cwd = {
-                    command = "$FD '/bin/python$' $CWD --full-path --color never -HI -a -L -E /proc -E .git/ -E .wine/ -E .steam/ -E Steam/ -E site-packages/",
+                    command = { "$FD", "/bin/python$", "$CWD", "--full-path", "--color", "never", "-HI", "-a", "-L", "-E", "/proc", "-E", ".git/", "-E", ".wine/", "-E", ".steam/", "-E", "Steam/", "-E", "site-packages/" },
                 },
                 workspace = {
-                    command = "$FD '/bin/python$' $WORKSPACE_PATH --full-path --color never -E /proc -HI -a -L",
+                    command = { "$FD", "/bin/python$", "$WORKSPACE_PATH", "--full-path", "--color", "never", "-E", "/proc", "-HI", "-a", "-L" },
                 },
                 file = {
-                    command = "$FD '/bin/python$' $FILE_DIR --full-path --color never -E /proc -HI -a -L",
+                    command = { "$FD", "/bin/python$", "$FILE_DIR", "--full-path", "--color", "never", "-E", "/proc", "-HI", "-a", "-L" },
                 },
             }
         end,
@@ -105,44 +106,44 @@ function M.get_default_searches()
             -- NOTE: In lua, '\' is an escape character. So in windows paths, we need 4 slashes where there normally would be 2 slashes on the command line.
             return {
                 hatch = {
-                    command = "$FD python.exe $HOME/AppData/Local/hatch/env/virtual --full-path --color never",
+                    command = { "$FD", "python.exe", "$HOME/AppData/Local/hatch/env/virtual", "--full-path", "--color", "never" },
                 },
                 poetry = {
-                    command = "$FD python.exe$ $HOME/AppData/Local/pypoetry/Cache/virtualenvs --full-path --color never",
+                    command = { "$FD", "python.exe$", "$HOME/AppData/Local/pypoetry/Cache/virtualenvs", "--full-path", "--color", "never" },
                 },
                 pyenv = {
-                    command = "$FD python.exe$ $HOME/.pyenv/pyenv-win/versions $HOME/.pyenv-win-venv/envs -E Lib",
+                    command = { "$FD", "python.exe$", "$HOME/.pyenv/pyenv-win/versions", "$HOME/.pyenv-win-venv/envs", "-E", "Lib" },
                 },
                 pipenv = {
-                    command = "$FD python.exe$ $HOME/.virtualenvs --full-path --color never",
+                    command = { "$FD", "python.exe$", "$HOME/.virtualenvs", "--full-path", "--color", "never" },
                 },
                 anaconda_envs = {
-                    command = "$FD python.exe$ $HOME/anaconda3/envs --full-path -a -E Lib",
+                    command = { "$FD", "python.exe$", "$HOME/anaconda3/envs", "--full-path", "-a", "-E", "Lib" },
                     type = "anaconda",
                 },
                 anaconda_base = {
-                    command = "$FD anaconda3\\\\python.exe $HOME/anaconda3 --full-path -a --color never",
+                    command = { "$FD", "anaconda3\\\\python.exe", "$HOME/anaconda3", "--full-path", "-a", "--color", "never" },
                     type = "anaconda",
                 },
                 miniconda_envs = {
-                    command = "$FD python.exe$ $HOME/miniconda3/envs --full-path -a -E Lib",
+                    command = { "$FD", "python.exe$", "$HOME/miniconda3/envs", "--full-path", "-a", "-E", "Lib" },
                     type = "anaconda",
                 },
                 miniconda_base = {
-                    command = "$FD miniconda3\\\\python.exe $HOME/miniconda3 --full-path -a --color never",
+                    command = { "$FD", "miniconda3\\\\python.exe", "$HOME/miniconda3", "--full-path", "-a", "--color", "never" },
                     type = "anaconda",
                 },
                 pipx = {
-                    command = "fd Scripts\\\\python.exe $HOME/pipx/venvs --full-path -a --color never",
+                    command = { "$FD", "Scripts\\\\python.exe", "$HOME/pipx/venvs", "--full-path", "-a", "--color", "never" },
                 },
                 cwd = {
-                    command = "$FD Scripts\\\\python.exe$ $CWD --full-path --color never -HI -a -L",
+                    command = { "$FD", "Scripts\\\\python.exe$", "$CWD", "--full-path", "--color", "never", "-HI", "-a", "-L" },
                 },
                 workspace = {
-                    command = "$FD Scripts\\\\python.exe$ $WORKSPACE_PATH --full-path --color never -HI -a -L",
+                    command = { "$FD", "Scripts\\\\python.exe$", "$WORKSPACE_PATH", "--full-path", "--color", "never", "-HI", "-a", "-L" },
                 },
                 file = {
-                    command = "$FD Scripts\\\\python.exe$ $FILE_DIR --full-path --color never -HI -a -L",
+                    command = { "$FD", "Scripts\\\\python.exe$", "$FILE_DIR", "--full-path", "--color", "never", "-HI", "-a", "-L" },
                 },
             }
         end,

--- a/lua/venv-selector/search.lua
+++ b/lua/venv-selector/search.lua
@@ -29,11 +29,16 @@ local function disable_default_searches(search_settings)
 end
 
 local function set_interactive_search(opts)
-    if opts ~= nil and #opts.args > 0 then
+    if opts ~= nil and #opts.fargs > 0 then
+        for index, value in ipairs(opts.fargs) do
+            if value == "$CWD" then
+                opts.fargs[index] = vim.fn.getcwd()
+            end
+        end
         local settings = {
             search = {
                 interactive = {
-                    command = opts.args:gsub("%$CWD", vim.fn.getcwd()),
+                    command = opts.fargs,
                 },
             },
         }
@@ -116,10 +121,14 @@ local function run_search(opts)
 
     local uv = vim.loop
     local function start_search_job(job_name, search, count)
-        local job = path.expand(search.execute_command)
-        log.debug("Starting '" .. job_name .. "': '" .. job .. "'")
+        if type(search.command) == "table" then
+            log.debug("Starting '" .. job_name .. "': '" .. table.concat(search.execute_command, " ") .. "'")
+        else
+            search.execute_command = path.expand(search.execute_command)
+            log.debug("Starting '" .. job_name .. "': '" .. search.execute_command .. "'")
+        end
         M.search_in_progress = true
-        local job_id = vim.fn.jobstart(job, {
+        local job_id = vim.fn.jobstart(search.execute_command, {
             stdout_buffered = true,
             stderr_buffered = true,
             on_stdout = on_event,
@@ -170,28 +179,67 @@ local function run_search(opts)
     -- Start search jobs from config
     for job_name, search in pairs(search_settings.search) do
         if search ~= false then -- Can be set to false by user to not search path
-            search.execute_command = search.command:gsub("$FD", options.fd_binary_name)
-
-            -- search has $WORKSPACE_PATH inside - dont start it unless the lsp has discovered workspace folders
-            if is_workspace_search(search.command) then
-                local workspace_folders = workspace.list_folders()
-                for _, workspace_path in pairs(workspace_folders) do
-                    search.execute_command = search.execute_command:gsub("$WORKSPACE_PATH", workspace_path)
-                    job_count = start_search_job(job_name, search, job_count)
+            if type(search.command) == "table" then
+                search.execute_command = vim.deepcopy(search.command)
+                if search.command[1] == "$FD" then
+                    search.execute_command[1] = options.fd_binary_name
                 end
-            -- search has $CWD inside
-            elseif is_cwd_search(search.command) then
-                search.execute_command = search.execute_command:gsub("$CWD", cwd)
-                job_count = start_search_job(job_name, search, job_count)
-            -- search has $FILE_DIR inside
-            elseif is_filepath_search(search.command) then
-                if current_dir ~= nil then
-                    search.execute_command = search.execute_command:gsub("$FILE_DIR", current_dir)
+
+                local should_start = true
+                for index, value in ipairs(search.command) do
+                    -- search has $WORKSPACE_PATH inside - dont start it unless the lsp has discovered workspace folders
+                    if value == "$WORKSPACE_PATH" then
+                        local workspace_folders = workspace.list_folders()
+                        if #workspace_folders > 0 then
+                            table.remove(search.execute_command, index)
+                            for _, workspace_path in pairs(workspace_folders) do
+                                table.insert(search.execute_command, index, workspace_path)
+                            end
+                        else
+                            should_start = false
+                            break
+                        end
+                    -- search has $CWD inside
+                    elseif value == "$CWD" then
+                        search.execute_command[index] = cwd
+                    -- search has $FILE_DIR inside
+                    elseif value == "$FILE_DIR" then
+                        if current_dir ~= nil then
+                            search.execute_command[index] = current_dir
+                        else
+                            should_start = false
+                            break
+                        end
+                    end
+                    search.execute_command[index] = path.expand(search.execute_command[index])
+                end
+                if should_start then
                     job_count = start_search_job(job_name, search, job_count)
                 end
             else
-                -- search has no keywords inside
-                job_count = start_search_job(job_name, search, job_count)
+                search.execute_command = search.command:gsub("$FD", options.fd_binary_name)
+
+                -- search has $WORKSPACE_PATH inside - dont start it unless the lsp has discovered workspace folders
+                if is_workspace_search(search.command) then
+                    local workspace_folders = workspace.list_folders()
+                    for _, workspace_path in pairs(workspace_folders) do
+                        search.execute_command = search.execute_command:gsub("$WORKSPACE_PATH", workspace_path)
+                        job_count = start_search_job(job_name, search, job_count)
+                    end
+                -- search has $CWD inside
+                elseif is_cwd_search(search.command) then
+                    search.execute_command = search.execute_command:gsub("$CWD", cwd)
+                    job_count = start_search_job(job_name, search, job_count)
+                -- search has $FILE_DIR inside
+                elseif is_filepath_search(search.command) then
+                    if current_dir ~= nil then
+                        search.execute_command = search.execute_command:gsub("$FILE_DIR", current_dir)
+                        job_count = start_search_job(job_name, search, job_count)
+                    end
+                else
+                    -- search has no keywords inside
+                    job_count = start_search_job(job_name, search, job_count)
+                end
             end
         end
     end


### PR DESCRIPTION
Related #158 

There are too many shell environment on Windows. If you just use cmd or powershell, you can get results correctly because they do not automatically set the `SHELL` environment variable, neovim will use the default values for the options `shell` and `shellcmdflag`.

If you use shell on msys2 subsystem, like Git Bash or zsh, they automatically set the `SHELL` environment variable and neovim will change the value of the option `shell` but no `shellcmdflags`, so there is no result. Even if you set the correct `shell` and `shellcmdflag` option values, in some cases you will need even eight backslashes to get results correctly!

Letting the job run directly can fix this problem, makes the shell irrelevant.

But this PR just a quick workaround, for example, the folder in the command must not have spaces.

Perhaps rewriting the command string as a list (make the shell irrelevant on all platforms) would be a good idea, Something like from
```lua
command = "$FD 'python$' ~/.virtualenvs --color never"
```
to
```lua
command = { "$FD", "python$", "~/.virtualenvs", "--color", "never" }
```