### PR TITLE
feat: expose activate function

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,4 +438,4 @@ These functions can be used to easily get the selected python interpreter and th
 - `require("venv-selector").file_dir()`         -- Gives back the directory of the currently opened file
 - `require("venv-selector").deactivate()`       -- Removes the venv from terminal path and unsets environment variables
 - `require("venv-selector").stop_lsp_servers()` -- Stops the lsp servers used by the plugin
-
+- `require("venv-selector").activate_from_path(python_path)` -- Activates a python interpreter given a path to it

--- a/README.md
+++ b/README.md
@@ -439,3 +439,5 @@ These functions can be used to easily get the selected python interpreter and th
 - `require("venv-selector").deactivate()`       -- Removes the venv from terminal path and unsets environment variables
 - `require("venv-selector").stop_lsp_servers()` -- Stops the lsp servers used by the plugin
 - `require("venv-selector").activate_from_path(python_path)` -- Activates a python interpreter given a path to it
+
+IMPORTANT: The last function, `activate_from_path`, is only intended as a way to select a virtual environment python without using the telescope picker. Trying to activate the system python this way is not supported and will set environment variables like `VIRTUAL_ENV` to the wrong values, since the plugin expects the path to be a virtual environment.

--- a/lua/venv-selector/cached_venv.lua
+++ b/lua/venv-selector/cached_venv.lua
@@ -13,7 +13,7 @@ function M.create_dir()
     end
 end
 
-function M.save(python_path, venv_type, venv_source)
+function M.save(python_path, venv_type)
     if config.user_settings.options.enable_cached_venvs ~= true then
         log.debug("Option 'enable_cached_venvs' is false so will not use cache.")
         return
@@ -25,7 +25,6 @@ function M.save(python_path, venv_type, venv_source)
         [vim.fn.getcwd()] = {
             value = python_path,
             type = venv_type,
-            source = venv_source,
         },
     }
 
@@ -66,7 +65,7 @@ function M.retrieve()
                 local venv_info = venv_cache[vim.fn.getcwd()]
 
                 log.debug("Activating venv `" .. venv_info.value .. "` from cache.")
-                venv.activate(venv_info.value, venv_info.type, venv_info.source, false)
+                venv.activate(venv_info.value, venv_info.type, false)
                 return
             end
         end

--- a/lua/venv-selector/cached_venv.lua
+++ b/lua/venv-selector/cached_venv.lua
@@ -63,7 +63,10 @@ function M.retrieve()
             local venv_cache = vim.fn.json_decode(cache_file_content[1])
             if venv_cache ~= nil and venv_cache[vim.fn.getcwd()] ~= nil then
                 local venv = require("venv-selector.venv")
-                venv.activate_from_cache(config.default_settings, venv_cache[vim.fn.getcwd()])
+                local venv_info = venv_cache[vim.fn.getcwd()]
+
+                log.debug("Activating venv `" .. venv_info.value .. "` from cache.")
+                venv.activate(venv_info.value, venv_info.type, venv_info.source, false)
                 return
             end
         end

--- a/lua/venv-selector/gui.lua
+++ b/lua/venv-selector/gui.lua
@@ -235,7 +235,8 @@ function M.open(in_progress)
             map({ "i", "n" }, "<cr>", function()
                 local selected_entry = actions_state.get_selected_entry()
                 if selected_entry ~= nil then
-                    venv.activate(selected_entry.path, selected_entry.type, selected_entry.source, true)
+                    venv.set_source(selected_entry.source)
+                    venv.activate(selected_entry.path, selected_entry.type, true)
                 end
                 actions.close(bufnr)
             end)

--- a/lua/venv-selector/gui.lua
+++ b/lua/venv-selector/gui.lua
@@ -234,22 +234,8 @@ function M.open(in_progress)
         attach_mappings = function(bufnr, map)
             map({ "i", "n" }, "<cr>", function()
                 local selected_entry = actions_state.get_selected_entry()
-                local activated = false
                 if selected_entry ~= nil then
-                    activated = venv.activate(config.user_settings.hooks, selected_entry)
-                    if activated == true then
-                        path.add(path.get_base(selected_entry.path))
-                        path.update_python_dap(selected_entry.path)
-                        path.save_selected_python(selected_entry.path)
-
-                        if selected_entry.type == "anaconda" then
-                            venv.unset_env("VIRTUAL_ENV")
-                            venv.set_env(selected_entry.path, "CONDA_PREFIX")
-                        else
-                            venv.unset_env("CONDA_PREFIX")
-                            venv.set_env(selected_entry.path, "VIRTUAL_ENV")
-                        end
-                    end
+                    venv.activate(selected_entry.path, selected_entry.type, selected_entry.source, true)
                 end
                 actions.close(bufnr)
             end)

--- a/lua/venv-selector/init.lua
+++ b/lua/venv-selector/init.lua
@@ -51,8 +51,8 @@ function M.stop_lsp_servers()
     venv.stop_lsp_servers()
 end
 
-function M.activate(python_path, type)
-    venv.activate(python_path, type, true)
+function M.activate_from_path(python_path)
+    venv.activate(python_path, "activate_from_path", true)
 end
 
 function M.deactivate()

--- a/lua/venv-selector/init.lua
+++ b/lua/venv-selector/init.lua
@@ -51,6 +51,10 @@ function M.stop_lsp_servers()
     venv.stop_lsp_servers()
 end
 
+function M.activate(python_path, type)
+    venv.activate(python_path, type, true)
+end
+
 function M.deactivate()
     path.remove_current()
     venv.unset_env_variables()

--- a/lua/venv-selector/venv.lua
+++ b/lua/venv-selector/venv.lua
@@ -13,16 +13,20 @@ function M.stop_lsp_servers()
     end
 end
 
+function M.set_source(source)
+    log.debug('Setting require("venv-selector").source() to \'' .. source .. "'")
+    M.current_source = source
+end
+
 --- Activate a virtual environment.
 ---
 --- This function will update the paths and environment variables to the selected virtual environment,
 --- and inform the lsp servers about the change.
 ---@param venv_path string The path to the python executable in the virtual environment.
 ---@param type string The type of the virtual environment. This is used to determine which environment variable to set (e.g. conda or venv)
----@param source string The search source of the virtual environment.
 ---@param check_lsp boolean Whether to check if lsp servers are running before activating the virtual environment.
 ---@return boolean activated Whether the virtual environment was activated successfully.
-function M.activate(venv_path, type, source, check_lsp)
+function M.activate(venv_path, type, check_lsp)
     if venv_path == nil then
         return false
     end
@@ -35,7 +39,6 @@ function M.activate(venv_path, type, source, check_lsp)
     -- Set the below two variables as quick as possible since its used in sorting results in telescope
     -- and if the user is quick to open the telescope before lsp has activated, the selected
     -- venv wont be displayed otherwise.
-    local path = require("venv-selector.path")
     path.current_python_path = venv_path
     path.current_venv_path = path.get_base(venv_path)
 
@@ -55,14 +58,12 @@ function M.activate(venv_path, type, source, check_lsp)
     end
 
     local cache = require("venv-selector.cached_venv")
-    cache.save(venv_path, type, source)
+    cache.save(venv_path, type)
 
     M.update_paths(venv_path, type)
 
     local on_venv_activate_callback = config.user_settings.options.on_venv_activate_callback
     if on_venv_activate_callback ~= nil then
-        M.current_source = source
-        log.debug('Setting require("venv-selector").source() to \'' .. source .. "'")
         log.debug("Calling on_venv_activate_callback() function")
         on_venv_activate_callback()
     end
@@ -71,7 +72,6 @@ function M.activate(venv_path, type, source, check_lsp)
 end
 
 function M.update_paths(venv_path, type)
-    local path = require("venv-selector.path")
     path.add(path.get_base(venv_path))
     path.update_python_dap(venv_path)
     path.save_selected_python(venv_path)

--- a/lua/venv-selector/venv.lua
+++ b/lua/venv-selector/venv.lua
@@ -22,31 +22,31 @@ end
 ---
 --- This function will update the paths and environment variables to the selected virtual environment,
 --- and inform the lsp servers about the change.
----@param venv_path string The path to the python executable in the virtual environment.
+---@param python_path string The path to the python executable in the virtual environment.
 ---@param type string The type of the virtual environment. This is used to determine which environment variable to set (e.g. conda or venv)
 ---@param check_lsp boolean Whether to check if lsp servers are running before activating the virtual environment.
 ---@return boolean activated Whether the virtual environment was activated successfully.
-function M.activate(venv_path, type, check_lsp)
-    if venv_path == nil then
+function M.activate(python_path, type, check_lsp)
+    if python_path == nil then
         return false
     end
 
-    if vim.fn.filereadable(venv_path) ~= 1 then
-        log.debug("Venv `" .. venv_path .. "` doesnt exist so cant activate it.")
+    if vim.fn.filereadable(python_path) ~= 1 then
+        log.debug("Venv `" .. python_path .. "` doesnt exist so cant activate it.")
         return false
     end
 
     -- Set the below two variables as quick as possible since its used in sorting results in telescope
     -- and if the user is quick to open the telescope before lsp has activated, the selected
     -- venv wont be displayed otherwise.
-    path.current_python_path = venv_path
-    path.current_venv_path = path.get_base(venv_path)
+    path.current_python_path = python_path
+    path.current_venv_path = path.get_base(python_path)
 
     -- Inform lsp servers
     local count = 0
     local hooks = require("venv-selector.config").user_settings.hooks
     for _, hook in pairs(hooks) do
-        count = count + hook(venv_path)
+        count = count + hook(python_path)
     end
 
     if check_lsp and count == 0 and config.user_settings.options.require_lsp_activation == true then
@@ -58,9 +58,9 @@ function M.activate(venv_path, type, check_lsp)
     end
 
     local cache = require("venv-selector.cached_venv")
-    cache.save(venv_path, type)
+    cache.save(python_path, type)
 
-    M.update_paths(venv_path, type)
+    M.update_paths(python_path, type)
 
     local on_venv_activate_callback = config.user_settings.options.on_venv_activate_callback
     if on_venv_activate_callback ~= nil then


### PR DESCRIPTION
Hi there,

First of all, thank you for this great plugin, I use it daily. 

I was trying to integrate this plugin with session switching via possession.nvim, and had the need to be able to manually activate virtual environments. Unfortunately, the `regexp` version does not expose an activate function, and the internal functions don't have a convenient interface for external use.

I made an attempt to slightly refactor the `venv` module to create a single `activate` function which does all the tasks one would expect. With this refactor, we can easily expose `M.activate(path, type)`. I have tried to keep the logic nearly identical during the refactor, but there are some slight changes, which I'll highlight in the comments.

Let me know if this is something you'd be willing to merge.
