### PR TITLE
feat: improve use of lsp hooks in user configuration options

### DIFF
--- a/lua/venv-selector/cached_venv.lua
+++ b/lua/venv-selector/cached_venv.lua
@@ -71,6 +71,9 @@ function M.retrieve()
             if venv_cache ~= nil and venv_cache[vim.fn.getcwd()] ~= nil then
                 local venv = require("venv-selector.venv")
                 local venv_info = venv_cache[vim.fn.getcwd()]
+                if venv_info.value == path.current_python_path then
+                    return
+                end
 
                 log.debug("Activating venv `" .. venv_info.value .. "` from cache.")
                 venv.activate(venv_info.value, venv_info.type, false)

--- a/lua/venv-selector/config.lua
+++ b/lua/venv-selector/config.lua
@@ -1,4 +1,3 @@
-local hooks = require("venv-selector.hooks")
 local log = require("venv-selector.logger")
 
 ---@class venv-selector.Options
@@ -20,7 +19,7 @@ local log = require("venv-selector.logger")
 
 ---@class venv-selector.Settings
 ---@field cache venv-selector.CacheSettings
----@field hooks venv-selector.Hook[]
+---@field lsp_hooks { basedpyright: boolean, pyright: boolean, pylance: boolean, pylsp: boolean}
 ---@field options venv-selector.Options
 ---@field search venv-selector.Searches set or override search commands
 
@@ -224,7 +223,7 @@ M.default_settings = {
     cache = {
         file = "~/.cache/venv-selector/venvs2.json",
     },
-    hooks = { hooks.basedpyright_hook, hooks.pyright_hook, hooks.pylance_hook, hooks.pylsp_hook },
+    lsp_hooks = { basedpyright = true, pyright = true, pylance = true, pylsp = true },
     options = {
         on_venv_activate_callback = nil, -- callback function for after a venv activates
         enable_default_searches = true, -- switches all default searches on/off

--- a/lua/venv-selector/hooks.lua
+++ b/lua/venv-selector/hooks.lua
@@ -1,6 +1,5 @@
+local config = require("venv-selector.config")
 local log = require("venv-selector.logger")
-
----@alias venv-selector.Hook fun(venv_python: string): nil
 
 local M = {}
 
@@ -31,7 +30,6 @@ function M.set_python_path_for_client(client_name, venv_python)
             return
         end
 
-        local config = require("venv-selector.config")
         if client.settings then
             client.settings = vim.tbl_deep_extend("force", client.settings, {
                 python = {
@@ -69,7 +67,6 @@ end
 function M.pylsp_hook(venv_python)
     local client_name = "pylsp"
     return M.execute_for_client(client_name, function(client)
-        local config = require("venv-selector.config")
         local settings = vim.tbl_deep_extend("force", (client.settings or client.config.settings), {
             pylsp = {
                 plugins = {
@@ -89,6 +86,17 @@ function M.pylsp_hook(venv_python)
         end
         log.info(message)
     end)
+end
+
+function M.notify_lsp(venv_python)
+    local count = 0
+    local hooks = config.user_settings.lsp_hooks
+    for name, enabled in pairs(hooks) do
+        if enabled then
+            count = count + M[name .. "_hook"](venv_python)
+        end
+    end
+    return count
 end
 
 function M.execute_for_client(name, callback)

--- a/lua/venv-selector/init.lua
+++ b/lua/venv-selector/init.lua
@@ -5,11 +5,14 @@ local venv = require("venv-selector.venv")
 local path = require("venv-selector.path")
 local ws = require("venv-selector.workspace")
 
-local function on_lsp_attach()
+local function on_lsp_attach(args)
     if vim.bo.filetype == "python" then
         local cache = require("venv-selector.cached_venv")
         if config.user_settings.options.cached_venv_automatic_activation == true then
-            cache.retrieve()
+            local client = vim.lsp.get_client_by_id(args.data.client_id)
+            if client and config.user_settings.lsp_hooks[client.name] then
+                cache.retrieve()
+            end
         end
     end
 end

--- a/lua/venv-selector/utils.lua
+++ b/lua/venv-selector/utils.lua
@@ -6,15 +6,6 @@ function M.table_has_content(t)
     return next(t) ~= nil
 end
 
-function M.merge_user_settings(user_settings)
-    log.debug("User plugin settings: ", user_settings.settings, "")
-    M.user_settings = vim.tbl_deep_extend("force", M.default_settings, user_settings.settings)
-    M.user_settings.detected = {
-        system = vim.loop.os_uname().sysname,
-    }
-    log.debug("Complete user settings:", M.user_settings, "")
-end
-
 -- split a string
 function M.split_string(str)
     local result = {}


### PR DESCRIPTION
- Improve hooks config.
  Users can simply configure the lsp hooks to be used with the Lua table. Example lazy.nvim plugin spec:
  ```lua
  {
    "linux-cultist/venv-selector.nvim",
    opts = {
      settings = {
        lsp_hooks = { pylsp = false },
      },
    },
  },
  ```
- Improve `LspAttach` event handler.
  Ruff or other lsp servers attached to the buffer will not be handled, so the value of `current_pyhon_path` will not be messed up. Multiple lsp notify can be prevented by the value of `current_python_path` and the value in venv cache file.
- Remove  a duplicate unused function.
  The function `merge_user_settings` is also in `utils.lua` but is not used.