### PR TITLE
Improve settings management

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@
   keys = {
     { ",v", "<cmd>VenvSelect<cr>" },
   },
+  ---@type venv-selector.Config
   opts = {
     -- Your settings go here
   },

--- a/README.md
+++ b/README.md
@@ -39,22 +39,22 @@
 
 ## Configuration snippet for [lazy.nvim](https://github.com/folke/lazy.nvim)
 
-```
+```lua
 {
   "linux-cultist/venv-selector.nvim",
-    dependencies = {
-      "neovim/nvim-lspconfig",
-      "mfussenegger/nvim-dap", "mfussenegger/nvim-dap-python", --optional
-      { "nvim-telescope/telescope.nvim", branch = "0.1.x", dependencies = { "nvim-lua/plenary.nvim" } },
-    },
+  dependencies = {
+    "neovim/nvim-lspconfig",
+    "mfussenegger/nvim-dap", "mfussenegger/nvim-dap-python", --optional
+    { "nvim-telescope/telescope.nvim", branch = "0.1.x", dependencies = { "nvim-lua/plenary.nvim" } },
+  },
   lazy = false,
   branch = "regexp", -- This is the regexp branch, use this for the new version
-  config = function()
-      require("venv-selector").setup()
-    end,
-    keys = {
-      { ",v", "<cmd>VenvSelect<cr>" },
-    },
+  keys = {
+    { ",v", "<cmd>VenvSelect<cr>" },
+  },
+  opts = {
+    -- Your settings go here
+  },
 },
 ```
 
@@ -112,17 +112,14 @@ The best way to craft a search is to run `fd` with your desired parameters on th
 
 The configuration looks like this:
 
-```
-      require("venv-selector").setup {
-        settings = {
-          search = {
-            my_venvs = {
-              command = "fd python$ ~/Code",
-            },
-          },
-        },
-      }
-
+```lua
+{
+  search = {
+    my_venvs = {
+      command = "fd python$ ~/Code",
+    },
+  },
+}
 ```
 The example command above launches a search for any path ending with `python` in the `~/Code` folder. Its using a regular expression where `python$` means the path must end with the word python. For windows we would need to use `python.exe$` instead. Here are the results:
 
@@ -138,19 +135,17 @@ These results will be shown in the telescope viewer and if they are a python vir
 
 You can add multiple searches as well:
 
-```
-      require("venv-selector").setup {
-        settings = {
-          search = {
-            find_code_venvs = {
-              command = "fd /bin/python$ ~/Code --full-path",
-            },
-            find_programming_venvs = {
-              command = "fd /bin/python$ ~/Programming/Python --full-path -IHL -E /proc",
-            },
-          },
-        },
-      }
+```lua
+{
+  search = {
+    find_code_venvs = {
+      command = "fd /bin/python$ ~/Code --full-path",
+    },
+    find_programming_venvs = {
+      command = "fd /bin/python$ ~/Programming/Python --full-path -IHL -E /proc",
+    },
+ },
+}
 ```
 
 Some notes about using quotes or not around the regexp:
@@ -165,20 +160,16 @@ If you need to create your own anaconda/miniconda search, you have to remember t
 
 Even if its a miniconda environment, the type needs to be anaconda since the same environment variables are set.
 
+```lua
+{
+  search = {
+    anaconda_base = {
+      command = "fd /python$ /opt/anaconda/bin --full-path --color never -E /proc",
+      type = "anaconda"
+    },
+  },
+}
 ```
-      require("venv-selector").setup {
-        settings = {
-          search = {
-            anaconda_base = {
-                command = "fd /python$ /opt/anaconda/bin --full-path --color never -E /proc",
-                type = "anaconda"
-            },
-          },
-        },
-      }
-
-```
-
 
 
 ## VenvSelect is slow for me, what can i do?
@@ -200,8 +191,8 @@ But sometimes its still so many files to search that it will become slow.
 
 Here is an example of *replacing* the default cwd search with one that **doesnt** search for hidden files. It replaces the cwd search since its named `cwd`.
 
-```
-settings = {
+```lua
+{
   search = {
     cwd = {
       command = "fd '/bin/python$' $CWD --full-path --color never -E /proc -I -a -L",
@@ -214,8 +205,8 @@ The most important difference compared to the default `cwd` search defined [here
 
 If you know that your venvs are in a specific location, you can also disable the default `cwd` search and write your own:
 
-```
-settings = {
+```lua
+{
   search = {
     cwd = false, -- setting this to false disables the default cwd search
     my_search = {
@@ -251,8 +242,8 @@ However, some flags slows down the search significantly and should not be used i
 ## Override or disable a default search
 
 If you want to **override** one of the default searches, create a search with the same name. This changes the default workspace search.
-```
-settings = {
+```lua
+{
   search = {
     workspace = {
       command = "fd /bin/python$ $WORKSPACE_PATH --full-path --color never -E /proc -unrestricted",
@@ -265,8 +256,8 @@ The above search adds the unrestriced flag to fd. See `fd` docs for what it does
 
 If you want to **disable one** of the default searches, you can simply set it to false. This disables the workspace search.
 
-```
-settings = {
+```lua
+{
   search = {
     workspace = false
   }
@@ -280,47 +271,39 @@ If you want to **disable all** built in searches, set the global option `enable_
 
 Maybe you dont want to see the entire full path to python in the telescope viewer. You can change whats being displayed by using a callback function.
 
-```
-{
+```lua
+-- This function gets called by the plugin when a new result from fd is received
+-- You can change the filename displayed here to what you like.
+-- Here in the example for linux/mac we replace the home directory with '~' and remove the /bin/python part.
+local function shorter_name(filename)
+   return filename:gsub(os.getenv("HOME"), "~"):gsub("/bin/python", "")
+end
+
+return {
   "linux-cultist/venv-selector.nvim",
-    dependencies = {
-      "neovim/nvim-lspconfig",
-      "mfussenegger/nvim-dap", "mfussenegger/nvim-dap-python", --both are optionals for debugging
-      { "nvim-telescope/telescope.nvim", branch = "0.1.x", dependencies = { "nvim-lua/plenary.nvim" } },
-    },
+  dependencies = {
+    "neovim/nvim-lspconfig",
+    "mfussenegger/nvim-dap", "mfussenegger/nvim-dap-python", --both are optionals for debugging
+    { "nvim-telescope/telescope.nvim", branch = "0.1.x", dependencies = { "nvim-lua/plenary.nvim" } },
+  },
   lazy = false,
   branch = "regexp", -- This is the regexp branch, use this for the new version
-  config = function()
-
-      -- This function gets called by the plugin when a new result from fd is received
-      -- You can change the filename displayed here to what you like.
-      -- Here in the example for linux/mac we replace the home directory with '~' and remove the /bin/python part.
-      local function shorter_name(filename)
-         return filename:gsub(os.getenv("HOME"), "~"):gsub("/bin/python", "")
-      end
-
-
-      require("venv-selector").setup {
-        settings = {
-          options = {
-            -- If you put the callback here as a global option, its used for all searches (including the default ones by the plugin)
-            on_telescope_result_callback = shorter_name
-          },
-
-          search = {
-            my_venvs = {
-              command = "fd python$ ~/Code", -- Sample command, need to be changed for your own venvs
-
-              -- If you put the callback here, its only called for your "my_venvs" search
-              on_telescope_result_callback = shorter_name
-            },
-          },
-        },
-      }
-    end,
-    keys = {
-      { ",v", "<cmd>VenvSelect<cr>" },
+  keys = {
+    { ",v", "<cmd>VenvSelect<cr>" },
+  },
+  opts = {
+    options = {
+      -- If you put the callback here as a global option, its used for all searches (including the default ones by the plugin)
+      on_telescope_result_callback = shorter_name
     },
+    search = {
+      my_venvs = {
+        command = "fd python$ ~/Code", -- Sample command, need to be changed for your own venvs
+        -- If you put the callback here, its only called for your "my_venvs" search
+        on_telescope_result_callback = shorter_name
+      },
+    },
+  },
 },
 ```
 
@@ -338,59 +321,34 @@ The function `on_venv_activate` sets up a neovim autocommand to run the function
 
 We only want to run the function once, which is why we have the `command_run` flag.
 
+```lua
+{
+  options = {
+    on_venv_activate_callback = function()
+      local command_run = false
 
+      local function run_shell_command()
+        local source = require("venv-selector").source()
+        local python = require("venv-selector").python()
 
-```
-  {
-    "linux-cultist/venv-selector.nvim",
-    dependencies = {
-      "neovim/nvim-lspconfig",
-      { "nvim-telescope/telescope.nvim", branch = "0.1.x", dependencies = { "nvim-lua/plenary.nvim" } },
-      "mfussenegger/nvim-dap",
-      "mfussenegger/nvim-dap-python",
-    },
-    lazy = false,
-    dev = true,
-    branch = "regexp",
-    config = function()
-      local function on_venv_activate()
-        local command_run = false
-
-        local function run_shell_command()
-          local source = require("venv-selector").source()
-          local python = require("venv-selector").python()
-
-          if source == "poetry" and command_run == false then
-            local command = "poetry env use " .. python
-            vim.api.nvim_feedkeys(command .. "\n", "n", false)
-            command_run = true
-          end
-
+        if source == "poetry" and command_run == false then
+          local command = "poetry env use " .. python
+          vim.api.nvim_feedkeys(command .. "\n", "n", false)
+          command_run = true
         end
 
-        vim.api.nvim_create_augroup("TerminalCommands", { clear = true })
-
-        vim.api.nvim_create_autocmd("TermEnter", {
-          group = "TerminalCommands",
-          pattern = "*",
-          callback = run_shell_command,
-        })
       end
 
+      vim.api.nvim_create_augroup("TerminalCommands", { clear = true })
 
-      require("venv-selector").setup {
-        settings = {
-          options = {
-            on_venv_activate_callback = on_venv_activate,
-          },
-        },
-      }
-    end,
-    keys = {
-      { ",v", "<cmd>VenvSelect<cr>" },
-    },
+      vim.api.nvim_create_autocmd("TermEnter", {
+        group = "TerminalCommands",
+        pattern = "*",
+        callback = run_shell_command,
+      })
+    end
   },
-
+}
 ```
 
 
@@ -402,29 +360,28 @@ You also need `debugpy` installed in the venv you are switching to.
 
 ## Global options to the plugin
 
-```
-settings = {
+```lua
+{
   options = {
-        on_venv_activate_callback = nil,           -- callback function for after a venv activates
-        enable_default_searches = true,            -- switches all default searches on/off
-        enable_cached_venvs = true,                -- use cached venvs that are activated automatically when a python file is registered with the LSP.
-        cached_venv_automatic_activation = true,   -- if set to false, the VenvSelectCached command becomes available to manually activate them.
-        activate_venv_in_terminal = true,          -- activate the selected python interpreter in terminal windows opened from neovim
-        set_environment_variables = true,          -- sets VIRTUAL_ENV or CONDA_PREFIX environment variables
-        notify_user_on_venv_activation = false,    -- notifies user on activation of the virtual env
-        search_timeout = 5,                        -- if a search takes longer than this many seconds, stop it and alert the user
-        debug = false,                             -- enables you to run the VenvSelectLog command to view debug logs
-        fd_binary_name = M.find_fd_command_name(), -- plugin looks for `fd` or `fdfind` but you can set something else here
-        require_lsp_activation = true,             -- require activation of an lsp before setting env variables
+    on_venv_activate_callback = nil,           -- callback function for after a venv activates
+    enable_default_searches = true,            -- switches all default searches on/off
+    enable_cached_venvs = true,                -- use cached venvs that are activated automatically when a python file is registered with the LSP.
+    cached_venv_automatic_activation = true,   -- if set to false, the VenvSelectCached command becomes available to manually activate them.
+    activate_venv_in_terminal = true,          -- activate the selected python interpreter in terminal windows opened from neovim
+    set_environment_variables = true,          -- sets VIRTUAL_ENV or CONDA_PREFIX environment variables
+    notify_user_on_venv_activation = false,    -- notifies user on activation of the virtual env
+    search_timeout = 5,                        -- if a search takes longer than this many seconds, stop it and alert the user
+    debug = false,                             -- enables you to run the VenvSelectLog command to view debug logs
+    fd_binary_name = M.find_fd_command_name(), -- plugin looks for `fd` or `fdfind` but you can set something else here
+    require_lsp_activation = true,             -- require activation of an lsp before setting env variables
 
-        -- telescope viewer options
-        on_telescope_result_callback = nil,        -- callback function for modifying telescope results
-        show_telescope_search_type = true,         -- shows which of the searches found which venv in telescope
-        telescope_filter_type = "substring"        -- when you type something in telescope, filter by "substring" or "character"
-        telescope_active_venv_color = "#00FF00"    -- The color of the active venv in telescope
+    -- telescope viewer options
+    on_telescope_result_callback = nil,        -- callback function for modifying telescope results
+    show_telescope_search_type = true,         -- shows which of the searches found which venv in telescope
+    telescope_filter_type = "substring"        -- when you type something in telescope, filter by "substring" or "character"
+    telescope_active_venv_color = "#00FF00"    -- The color of the active venv in telescope
   }
 }
-
 ```
 
 ## Exposed functions
@@ -441,4 +398,7 @@ These functions can be used to easily get the selected python interpreter and th
 - `require("venv-selector").stop_lsp_servers()` -- Stops the lsp servers used by the plugin
 - `require("venv-selector").activate_from_path(python_path)` -- Activates a python interpreter given a path to it
 
-IMPORTANT: The last function, `activate_from_path`, is only intended as a way to select a virtual environment python without using the telescope picker. Trying to activate the system python this way is not supported and will set environment variables like `VIRTUAL_ENV` to the wrong values, since the plugin expects the path to be a virtual environment.
+> [!IMPORTANT]
+> The last function, `activate_from_path`, is only intended as a way to select a virtual environment python without using the telescope picker.
+> Trying to activate the system python this way is not supported and will set environment variables like `VIRTUAL_ENV` to the wrong values, 
+> since the plugin expects the path to be a virtual environment.

--- a/lua/venv-selector/cached_venv.lua
+++ b/lua/venv-selector/cached_venv.lua
@@ -2,6 +2,9 @@ local config = require("venv-selector.config")
 local path = require("venv-selector.path")
 local log = require("venv-selector.logger")
 
+---@class venv-selector.CacheSettings
+---@field file string  Path to the cache file
+
 local cache_file = path.expand(config.user_settings.cache.file)
 local base_dir = path.get_base(cache_file)
 

--- a/lua/venv-selector/config.lua
+++ b/lua/venv-selector/config.lua
@@ -1,8 +1,42 @@
 local hooks = require("venv-selector.hooks")
 local log = require("venv-selector.logger")
 
+---@class venv-selector.Options
+---@field on_venv_activate_callback? fun(): nil callback function for after a venv activates
+---@field enable_default_searches boolean switches all default searches on/off
+---@field enable_cached_venvs boolean use cached venvs that are activated automatically when a python file is registered with the LSP.
+---@field cached_venv_automatic_activation boolean if set to false, the VenvSelectCached command becomes available to manually activate them.
+---@field activate_venv_in_terminal boolean activate the selected python interpreter in terminal windows opened from neovim
+---@field set_environment_variables boolean sets VIRTUAL_ENV or CONDA_PREFIX environment variables
+---@field notify_user_on_venv_activation boolean notifies user on activation of the virtual env
+---@field search_timeout integer if a search takes longer than this many seconds, stop it and alert the user
+---@field debug boolean enables you to run the VenvSelectLog command to view debug logs
+---@field fd_binary_name string plugin looks for `fd` or `fdfind` but you can set something else here
+---@field require_lsp_activation boolean require activation of an lsp before setting env variables
+---@field on_telescope_result_callback? fun(filename: string): string callback function for modifying telescope results
+---@field show_telescope_search_type boolean Shows which of the searches found which venv in telescope
+---@field telescope_filter_type "substring" | "character" When you type something in telescope, filter by "substring" or "character"
+---@field telescope_active_venv_color string The color of the active venv in telescope
+
+---@class venv-selector.Settings
+---@field cache venv-selector.CacheSettings
+---@field hooks venv-selector.Hook[]
+---@field options venv-selector.Options
+---@field search venv-selector.Searches set or override search commands
+
+---@class (partial) venv-selector.Config: venv-selector.Settings
+
+---@class venv-selector.Detected
+---@field system string the detected system name
+
+---@class (partial) venv-selector.UserSettings: venv-selector.Settings
+---@field detected venv-selector.Detected
+
+
 local M = {}
 
+---@type venv-selector.UserSettings
+---@diagnostic disable-next-line: missing-fields
 M.user_settings = {}
 
 --- Health check tracking of legacy settings
@@ -157,12 +191,16 @@ function M.get_default_searches()
     return systems[name] or systems["Linux"]
 end
 
+---@param user_settings venv-selector.Settings
 function M.merge_user_settings(user_settings)
+    ---@diagnostic disable-next-line: undefined-field
     if user_settings.settings ~= nil then
+        ---@diagnostic disable-next-line: undefined-field
         user_settings = user_settings.settings
         M.has_legacy_settings = true
     end
     log.debug("User plugin settings: ", user_settings, "")
+    ---@diagnostic disable-next-line: assign-type-mismatch
     M.user_settings = vim.tbl_deep_extend("force", M.default_settings, user_settings or {})
 
     M.user_settings.detected = {
@@ -181,6 +219,7 @@ function M.find_fd_command_name()
     end
 end
 
+---@type venv-selector.Settings
 M.default_settings = {
     cache = {
         file = "~/.cache/venv-selector/venvs2.json",

--- a/lua/venv-selector/config.lua
+++ b/lua/venv-selector/config.lua
@@ -5,6 +5,10 @@ local M = {}
 
 M.user_settings = {}
 
+--- Health check tracking of legacy settings
+---@type boolean
+M.has_legacy_settings = false
+
 function M.get_default_searches()
     local systems = {
         ["Linux"] = function()
@@ -154,8 +158,12 @@ function M.get_default_searches()
 end
 
 function M.merge_user_settings(user_settings)
-    log.debug("User plugin settings: ", user_settings.settings, "")
-    M.user_settings = vim.tbl_deep_extend("force", M.default_settings, user_settings.settings or {})
+    if user_settings.settings ~= nil then
+        user_settings = user_settings.settings
+        M.has_legacy_settings = true
+    end
+    log.debug("User plugin settings: ", user_settings, "")
+    M.user_settings = vim.tbl_deep_extend("force", M.default_settings, user_settings or {})
 
     M.user_settings.detected = {
         system = vim.loop.os_uname().sysname,

--- a/lua/venv-selector/health.lua
+++ b/lua/venv-selector/health.lua
@@ -1,0 +1,13 @@
+local M = {}
+
+M.check = function()
+  vim.health.start("venv-selector")
+  local config = require("venv-selector.config")
+  if config.has_legacy_settings then
+    vim.health.warn("Legacy settings detected", "Remove the wrapping `settings` key from `setup()` options")
+  else
+    vim.health.ok("Settings are correct")
+  end
+end
+
+return M

--- a/lua/venv-selector/hooks.lua
+++ b/lua/venv-selector/hooks.lua
@@ -1,5 +1,7 @@
 local log = require("venv-selector.logger")
 
+---@alias venv-selector.Hook fun(venv_python: string): nil
+
 local M = {}
 
 M.notifications_memory = {}

--- a/lua/venv-selector/init.lua
+++ b/lua/venv-selector/init.lua
@@ -64,6 +64,7 @@ function M.deactivate()
     venv.unset_env_variables()
 end
 
+---@param plugin_settings venv-selector.Config
 function M.setup(plugin_settings)
     config.merge_user_settings(plugin_settings or {})
     vim.api.nvim_command("hi VenvSelectActiveVenv guifg=" .. config.user_settings.options.telescope_active_venv_color)

--- a/lua/venv-selector/search.lua
+++ b/lua/venv-selector/search.lua
@@ -4,6 +4,17 @@ local path = require("venv-selector.path")
 local utils = require("venv-selector.utils")
 local log = require("venv-selector.logger")
 
+
+---@alias venv-selector.SearchType
+---| '"anaconda"' # an anaconda/minconda search
+
+---@class venv-selector.Search
+---@field command string The serch commnd to be executed
+---@field type? venv-selector.SearchType set for special venv types
+
+---@alias venv-selector.Searches table<string, venv-selector.Search|false>
+
+
 local function is_workspace_search(str)
     return string.find(str, "$WORKSPACE_PATH") ~= nil
 end


### PR DESCRIPTION
Hello 👋🏼 

First, thanks for this plugin!

I allowed myself to submit this PR adding multiple improvements to the settings handling:
- remove the unnecessary `settings` level (in a backward-compatible way)
- add a Neovim health check for it
- simplify the associated documentation (same indent, format... for all example, add syntax highlighting)
- follow `lazy.vim` recommendations in examples ([`opts` over `config`](https://lazy.folke.io/spec#spec-setup))
- add some [LuaCATS annotations](https://luals.github.io/wiki/annotations/), so users can benefit from completion and documentation from Lua LSP

Here's the health check for settings:
![image](https://github.com/user-attachments/assets/9d5957c3-2549-404d-812e-867e0e30a794)


You can see the rendered README [here](https://github.com/noirbizarre/venv-selector.nvim/tree/unwrap-settings#readme)