### PR TITLE
Wrap Environment Variable Paths in Quotes for FD Commands in config.lua

### DIFF
--- a/lua/venv-selector/config.lua
+++ b/lua/venv-selector/config.lua
@@ -44,13 +44,13 @@ function M.get_default_searches()
                     command = "$FD '/bin/python$' ~/.local/share/pipx/venvs ~/.local/pipx/venvs --full-path --color never",
                 },
                 cwd = {
-                    command = "$FD '/bin/python$' $CWD --full-path --color never -HI -a -L -E /proc -E .git/ -E .wine/ -E .steam/ -E Steam/ -E site-packages/",
+                    command = "$FD '/bin/python$' '$CWD' --full-path --color never -HI -a -L -E /proc -E .git/ -E .wine/ -E .steam/ -E Steam/ -E site-packages/",
                 },
                 workspace = {
-                    command = "$FD '/bin/python$' $WORKSPACE_PATH --full-path --color never -E /proc -HI -a -L",
+                    command = "$FD '/bin/python$' '$WORKSPACE_PATH' --full-path --color never -E /proc -HI -a -L",
                 },
                 file = {
-                    command = "$FD '/bin/python$' $FILE_DIR --full-path --color never -E /proc -HI -a -L",
+                    command = "$FD '/bin/python$' '$FILE_DIR' --full-path --color never -E /proc -HI -a -L",
                 },
             }
         end,
@@ -91,13 +91,13 @@ function M.get_default_searches()
                     command = "$FD '/bin/python$' ~/.local/share/pipx/venvs ~/.local/pipx/venvs --full-path --color never",
                 },
                 cwd = {
-                    command = "$FD '/bin/python$' $CWD --full-path --color never -HI -a -L -E /proc -E .git/ -E .wine/ -E .steam/ -E Steam/ -E site-packages/",
+                    command = "$FD '/bin/python$' '$CWD' --full-path --color never -HI -a -L -E /proc -E .git/ -E .wine/ -E .steam/ -E Steam/ -E site-packages/",
                 },
                 workspace = {
-                    command = "$FD '/bin/python$' $WORKSPACE_PATH --full-path --color never -E /proc -HI -a -L",
+                    command = "$FD '/bin/python$' '$WORKSPACE_PATH' --full-path --color never -E /proc -HI -a -L",
                 },
                 file = {
-                    command = "$FD '/bin/python$' $FILE_DIR --full-path --color never -E /proc -HI -a -L",
+                    command = "$FD '/bin/python$' '$FILE_DIR' --full-path --color never -E /proc -HI -a -L",
                 },
             }
         end,
@@ -137,13 +137,13 @@ function M.get_default_searches()
                     command = "$FD Scripts//python.exe$ $HOME/pipx/venvs --full-path -a --color never",
                 },
                 cwd = {
-                    command = "$FD Scripts//python.exe$ $CWD --full-path --color never -HI -a -L",
+                    command = "$FD Scripts//python.exe$ '$CWD' --full-path --color never -HI -a -L",
                 },
                 workspace = {
-                    command = "$FD Scripts//python.exe$ $WORKSPACE_PATH --full-path --color never -HI -a -L",
+                    command = "$FD Scripts//python.exe$ '$WORKSPACE_PATH' --full-path --color never -HI -a -L",
                 },
                 file = {
-                    command = "$FD Scripts//python.exe$ $FILE_DIR --full-path --color never -HI -a -L",
+                    command = "$FD Scripts//python.exe$ '$FILE_DIR' --full-path --color never -HI -a -L",
                 },
             }
         end,


### PR DESCRIPTION
This pull request includes changes to the `function M.get_default_searches()` in the `lua/venv-selector/config.lua` file. The changes focus on ensuring the paths for various commands are correctly quoted to handle spaces and special characters.

Improvements to command paths:

* Updated the `cwd` command to quote the `$CWD` variable to handle spaces and special characters. [[1]](diffhunk://#diff-b279860ac73847386d4679b6b727027fb844fa45979de92d212c75c783bc8397L47-R53) [[2]](diffhunk://#diff-b279860ac73847386d4679b6b727027fb844fa45979de92d212c75c783bc8397L94-R100) [[3]](diffhunk://#diff-b279860ac73847386d4679b6b727027fb844fa45979de92d212c75c783bc8397L140-R146)
* Updated the `workspace` command to quote the `$WORKSPACE_PATH` variable to handle spaces and special characters. [[1]](diffhunk://#diff-b279860ac73847386d4679b6b727027fb844fa45979de92d212c75c783bc8397L47-R53) [[2]](diffhunk://#diff-b279860ac73847386d4679b6b727027fb844fa45979de92d212c75c783bc8397L94-R100) [[3]](diffhunk://#diff-b279860ac73847386d4679b6b727027fb844fa45979de92d212c75c783bc8397L140-R146)
* Updated the `file` command to quote the `$FILE_DIR` variable to handle spaces and special characters. [[1]](diffhunk://#diff-b279860ac73847386d4679b6b727027fb844fa45979de92d212c75c783bc8397L47-R53) [[2]](diffhunk://#diff-b279860ac73847386d4679b6b727027fb844fa45979de92d212c75c783bc8397L94-R100) [[3]](diffhunk://#diff-b279860ac73847386d4679b6b727027fb844fa45979de92d212c75c783bc8397L140-R146)