### PR TITLE
Use --no-ignore-vcs in default searches

### DIFF
--- a/lua/venv-selector/config.lua
+++ b/lua/venv-selector/config.lua
@@ -10,22 +10,22 @@ function M.get_default_searches()
         ["Linux"] = function()
             return {
                 virtualenvs = {
-                    command = "$FD 'python$' ~/.virtualenvs --color never",
+                    command = "$FD 'python$' ~/.virtualenvs --no-ignore-vcs --color never",
                 },
                 hatch = {
-                    command = "$FD 'python$' ~/.local/share/hatch --color never -E '*-build*'",
+                    command = "$FD 'python$' ~/.local/share/hatch --no-ignore-vcs --color never -E '*-build*'",
                 },
                 poetry = {
-                    command = "$FD '/bin/python$' ~/.cache/pypoetry/virtualenvs --full-path",
+                    command = "$FD '/bin/python$' ~/.cache/pypoetry/virtualenvs --no-ignore-vcs --full-path",
                 },
                 pyenv = {
-                    command = "$FD '/bin/python$' ~/.pyenv/versions --full-path --color never -E pkgs/ -E envs/ -L",
+                    command = "$FD '/bin/python$' ~/.pyenv/versions --no-ignore-vcs --full-path --color never -E pkgs/ -E envs/ -L",
                 },
                 pipenv = {
-                    command = "$FD '/bin/python$' ~/.local/share/virtualenvs --full-path --color never",
+                    command = "$FD '/bin/python$' ~/.local/share/virtualenvs --no-ignore-vcs --full-path --color never",
                 },
                 anaconda_envs = {
-                    command = "$FD 'bin/python$' ~/.conda/envs --full-path --color never",
+                    command = "$FD 'bin/python$' ~/.conda/envs --no-ignore-vcs --full-path --color never",
                     type = "anaconda",
                 },
                 anaconda_base = {
@@ -33,15 +33,15 @@ function M.get_default_searches()
                     type = "anaconda",
                 },
                 miniconda_envs = {
-                    command = "$FD 'bin/python$' ~/miniconda3/envs --full-path --color never",
+                    command = "$FD 'bin/python$' ~/miniconda3/envs --no-ignore-vcs --full-path --color never",
                     type = "anaconda",
                 },
                 miniconda_base = {
-                    command = "$FD '/python$' ~/miniconda3/bin --full-path --color never",
+                    command = "$FD '/python$' ~/miniconda3/bin --no-ignore-vcs --full-path --color never",
                     type = "anaconda",
                 },
                 pipx = {
-                    command = "$FD '/bin/python$' ~/.local/share/pipx/venvs ~/.local/pipx/venvs --full-path --color never",
+                    command = "$FD '/bin/python$' ~/.local/share/pipx/venvs ~/.local/pipx/venvs --no-ignore-vcs --full-path --color never",
                 },
                 cwd = {
                     command = "$FD '/bin/python$' $CWD --full-path --color never -HI -a -L -E /proc -E .git/ -E .wine/ -E .steam/ -E Steam/ -E site-packages/",
@@ -57,22 +57,22 @@ function M.get_default_searches()
         ["Darwin"] = function()
             return {
                 virtualenvs = {
-                    command = "$FD 'python$' ~/.virtualenvs --color never",
+                    command = "$FD 'python$' ~/.virtualenvs --no-ignore-vcs --color never",
                 },
                 hatch = {
-                    command = "$FD 'python$' ~/Library/Application\\\\ Support/hatch/env/virtual --color never -E '*-build*'",
+                    command = "$FD 'python$' ~/Library/Application\\\\ Support/hatch/env/virtual --no-ignore-vcs --color never -E '*-build*'",
                 },
                 poetry = {
-                    command = "$FD '/bin/python$' ~/Library/Caches/pypoetry/virtualenvs --full-path",
+                    command = "$FD '/bin/python$' ~/Library/Caches/pypoetry/virtualenvs --no-ignore-vcs --full-path",
                 },
                 pyenv = {
-                    command = "$FD '/bin/python$' ~/.pyenv/versions --full-path --color never -E pkgs/ -E envs/ -L",
+                    command = "$FD '/bin/python$' ~/.pyenv/versions --no-ignore-vcs --full-path --color never -E pkgs/ -E envs/ -L",
                 },
                 pipenv = {
-                    command = "$FD '/bin/python$' ~/.local/share/virtualenvs --full-path --color never",
+                    command = "$FD '/bin/python$' ~/.local/share/virtualenvs --no-ignore-vcs --full-path --color never",
                 },
                 anaconda_envs = {
-                    command = "$FD 'bin/python$' ~/.conda/envs --full-path --color never",
+                    command = "$FD 'bin/python$' ~/.conda/envs --no-ignore-vcs --full-path --color never",
                     type = "anaconda",
                 },
                 anaconda_base = {
@@ -80,15 +80,15 @@ function M.get_default_searches()
                     type = "anaconda",
                 },
                 miniconda_envs = {
-                    command = "$FD 'bin/python$' ~/miniconda3/envs --full-path --color never",
+                    command = "$FD 'bin/python$' ~/miniconda3/envs --no-ignore-vcs --full-path --color never",
                     type = "anaconda",
                 },
                 miniconda_base = {
-                    command = "$FD '/python$' ~/miniconda3/bin --full-path --color never",
+                    command = "$FD '/python$' ~/miniconda3/bin --no-ignore-vcs --full-path --color never",
                     type = "anaconda",
                 },
                 pipx = {
-                    command = "$FD '/bin/python$' ~/.local/share/pipx/venvs ~/.local/pipx/venvs --full-path --color never",
+                    command = "$FD '/bin/python$' ~/.local/share/pipx/venvs ~/.local/pipx/venvs --no-ignore-vcs --full-path --color never",
                 },
                 cwd = {
                     command = "$FD '/bin/python$' $CWD --full-path --color never -HI -a -L -E /proc -E .git/ -E .wine/ -E .steam/ -E Steam/ -E site-packages/",
@@ -106,35 +106,35 @@ function M.get_default_searches()
             -- a lot of escaping of the strings to get right.
             return {
                 hatch = {
-                    command = "$FD python.exe $HOME/AppData/Local/hatch/env/virtual --full-path --color never",
+                    command = "$FD python.exe $HOME/AppData/Local/hatch/env/virtual --no-ignore-vcs --full-path --color never",
                 },
                 poetry = {
-                    command = "$FD python.exe$ $HOME/AppData/Local/pypoetry/Cache/virtualenvs --full-path --color never",
+                    command = "$FD python.exe$ $HOME/AppData/Local/pypoetry/Cache/virtualenvs --no-ignore-vcs --full-path --color never",
                 },
                 pyenv = {
-                    command = "$FD python.exe$ $HOME/.pyenv/pyenv-win/versions $HOME/.pyenv-win-venv/envs -E Lib",
+                    command = "$FD python.exe$ $HOME/.pyenv/pyenv-win/versions $HOME/.pyenv-win-venv/envs --no-ignore-vcs -E Lib",
                 },
                 pipenv = {
-                    command = "$FD python.exe$ $HOME/.virtualenvs --full-path --color never",
+                    command = "$FD python.exe$ $HOME/.virtualenvs --no-ignore-vcs --full-path --color never",
                 },
                 anaconda_envs = {
-                    command = "$FD python.exe$ $HOME/anaconda3/envs --full-path -a -E Lib",
+                    command = "$FD python.exe$ $HOME/anaconda3/envs --no-ignore-vcs --full-path -a -E Lib",
                     type = "anaconda",
                 },
                 anaconda_base = {
-                    command = "$FD anaconda3//python.exe $HOME/anaconda3 --full-path -a --color never",
+                    command = "$FD anaconda3//python.exe $HOME/anaconda3 --no-ignore-vcs --full-path -a --color never",
                     type = "anaconda",
                 },
                 miniconda_envs = {
-                    command = "$FD python.exe$ $HOME/miniconda3/envs --full-path -a -E Lib",
+                    command = "$FD python.exe$ $HOME/miniconda3/envs --no-ignore-vcs --full-path -a -E Lib",
                     type = "anaconda",
                 },
                 miniconda_base = {
-                    command = "$FD miniconda3//python.exe $HOME/miniconda3 --full-path -a --color never",
+                    command = "$FD miniconda3//python.exe $HOME/miniconda3 --no-ignore-vcs --full-path -a --color never",
                     type = "anaconda",
                 },
                 pipx = {
-                    command = "$FD Scripts//python.exe$ $HOME/pipx/venvs --full-path -a --color never",
+                    command = "$FD Scripts//python.exe$ $HOME/pipx/venvs --no-ignore-vcs --full-path -a --color never",
                 },
                 cwd = {
                     command = "$FD Scripts//python.exe$ $CWD --full-path --color never -HI -a -L",


### PR DESCRIPTION
Newer versions of virtualenv add a .gitignore file containing a line with * in it, which ignores all files under the virtualenv. If the virtualenv happens to be under a git repository (such as when a user's home directory is tracked by git), fd will respect the gitignore files it sees in virtualenvs, causing venv-selector's default searches to fail to work as intended.