### PR TITLE
Add lsp_mypy support, and integration with lsp_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,26 @@ settings = {
 
 ```
 
+## Automatic venv support with lspconfig
+
+Lspconfig caches lsp clients and ideally would only receieve LSP config setting updates for changes
+in virtual env, or for new LSP clients.  To do this, set
+
+```
+cached_venv_automatic_activation = false
+```
+
+for `venv-selector` and configure an `on_init` callback for `lspconfig` like so:
+
+```
+    require("lspconfig").pylsp.setup({
+        on_init=require("venv-selector").on_lsp_init,
+        -- ...
+    })
+```
+
+This will cause venv activation (if one is cached) when the first client starts up.
+
 ## Exposed functions
 
 These functions can be used to easily get the selected python interpreter and the active venv.
@@ -440,5 +460,6 @@ These functions can be used to easily get the selected python interpreter and th
 - `require("venv-selector").deactivate()`       -- Removes the venv from terminal path and unsets environment variables
 - `require("venv-selector").stop_lsp_servers()` -- Stops the lsp servers used by the plugin
 - `require("venv-selector").activate_from_path(python_path)` -- Activates a python interpreter given a path to it
+- `require("venv-selector").on_lsp_init(client, result)` -- For use with lspconfig on_init, allows automatic venv selection
 
 IMPORTANT: The last function, `activate_from_path`, is only intended as a way to select a virtual environment python without using the telescope picker. Trying to activate the system python this way is not supported and will set environment variables like `VIRTUAL_ENV` to the wrong values, since the plugin expects the path to be a virtual environment.

--- a/lua/venv-selector/cached_venv.lua
+++ b/lua/venv-selector/cached_venv.lua
@@ -48,7 +48,7 @@ function M.save(python_path, venv_type)
     log.debug("Wrote cache content to " .. cache_file)
 end
 
-function M.retrieve()
+function _retrieve(project_path)
     if config.user_settings.options.enable_cached_venvs ~= true then
         log.debug("Option 'enable_cached_venvs' is false so will not use cache.")
         return
@@ -60,15 +60,27 @@ function M.retrieve()
 
         if cache_file_content ~= nil and cache_file_content[1] ~= nil then
             local venv_cache = vim.fn.json_decode(cache_file_content[1])
-            if venv_cache ~= nil and venv_cache[vim.fn.getcwd()] ~= nil then
+            if venv_cache ~= nil and venv_cache[project_path] ~= nil then
                 local venv = require("venv-selector.venv")
-                local venv_info = venv_cache[vim.fn.getcwd()]
+                local venv_info = venv_cache[project_path]
 
                 log.debug("Activating venv `" .. venv_info.value .. "` from cache.")
                 venv.activate(venv_info.value, venv_info.type, false)
                 return
             end
         end
+    end
+end
+
+function M.retrieve()
+    _retrieve(vim.fn.getcwd())
+end
+
+function M.retrieve_lspconfig(root_dir)
+    if root_dir ~= nil then
+        _retrieve(root_dir)
+    else
+        _retrieve(vim.fn.getcwd())
     end
 end
 

--- a/lua/venv-selector/hooks.lua
+++ b/lua/venv-selector/hooks.lua
@@ -74,6 +74,10 @@ function M.pylsp_hook(venv_python)
                     jedi = {
                         environment = venv_python,
                     },
+                    pylsp_mypy = {
+                        overrides = {true, "--python-executable", venv_python},
+                        mypy_command = (vim.fs.dirname(venv_python) .. "/mypy"),
+                    }
                 },
             },
         })

--- a/lua/venv-selector/init.lua
+++ b/lua/venv-selector/init.lua
@@ -64,14 +64,18 @@ function M.deactivate()
     venv.unset_env_variables()
 end
 
-function M.on_lsp_init(_, _)
+function M.on_lsp_init(client, _)
     -- for use with lspconfig
     -- provide to lspconfig.setup({
     --     on_init=require("venv-selector").on_lsp_init
     -- })
     -- Run the cached venv activate only once on init
     local cache = require("venv-selector.cached_venv")
-    cache.retrieve()
+    local root_dir = nil
+    if client ~= nil then
+        root_dir = client.root_dir
+    end
+    cache.retrieve_lspconfig(root_dir)
     local venv_python = require("venv-selector").python()
     if venv_python ~= nil then
         require("venv-selector.hooks").pylsp_hook(venv_python)

--- a/lua/venv-selector/init.lua
+++ b/lua/venv-selector/init.lua
@@ -64,6 +64,22 @@ function M.deactivate()
     venv.unset_env_variables()
 end
 
+function M.on_lsp_init(_, _)
+    -- for use with lspconfig
+    -- provide to lspconfig.setup({
+    --     on_init=require("venv-selector").on_lsp_init
+    -- })
+    -- Run the cached venv activate only once on init
+    local cache = require("venv-selector.cached_venv")
+    cache.retrieve()
+    local venv_python = require("venv-selector").python()
+    if venv_python ~= nil then
+        require("venv-selector.hooks").pylsp_hook(venv_python)
+    else
+        log.debug("No venv selected, skipping on_lsp_init")
+    end
+end
+
 function M.setup(plugin_settings)
     config.merge_user_settings(plugin_settings or {})
     vim.api.nvim_command("hi VenvSelectActiveVenv guifg=" .. config.user_settings.options.telescope_active_venv_color)


### PR DESCRIPTION
As per #187 the cached venv activation mechanism fires every time a new file is opened.  This causes issues for `pyslp_mypy`.  If using `lsp-config`, the lsp client is already cached per workspace, and rather than renotify, we can leverage that either a new lsp client needs to be launched (in which case `lsp-config`'s `on_init` will be called) or one is already running when a venv is selected, in which case we would want to notify it.

To do this we can disable automatic activation `cached_venv_automatic_activation = false` and set up a new call in `lsp-config` using a new function from `venv-selector`

```
    require("lspconfig").pylsp.setup({
        on_init=require("venv-selector").on_lsp_init,
        -- ...
    })
```

This PR also adds support for setting python paths for `pylsp_mypy` which is optional but should do no harm if the plugin isn't installed.
