### PR TITLE
fix: fix case where user has not explicitly set `debug` options

### DIFF
--- a/lua/venv-selector/init.lua
+++ b/lua/venv-selector/init.lua
@@ -66,7 +66,7 @@ end
 
 ---@param plugin_settings venv-selector.Config
 function M.setup(conf)
-    if conf.options.debug then
+    if vim.tbl_get(conf, "options", "debug") then
         log.enabled = true
     end
 


### PR DESCRIPTION
There is an issue with the current `setup` method where an error occurs unless the user explicitly sets `debug` options