### PR TITLE
Trigger auto-activation for UV PEP-723 on "python" file type instead of "*.py" file pattern

### DIFF
--- a/lua/venv-selector/uv.lua
+++ b/lua/venv-selector/uv.lua
@@ -208,8 +208,8 @@ end
 function M.setup_auto_activation()
     if M.uv_installed == true then
         -- Handle opening/switching files
-        vim.api.nvim_create_autocmd({ "BufEnter" }, {
-            pattern = "*.py",
+        vim.api.nvim_create_autocmd({ "BufEnter", "FileType" }, {
+            pattern = "python",
             callback = function()
                 vim.defer_fn(function()
                     local current_file = vim.fn.expand("%:p")
@@ -220,8 +220,8 @@ function M.setup_auto_activation()
         })
 
         -- Handle file saves (force recheck since metadata may have changed)
-        vim.api.nvim_create_autocmd({ "BufWrite" }, {
-            pattern = "*.py",
+        vim.api.nvim_create_autocmd({ "BufWrite", "FileType" }, {
+            pattern = "python",
             callback = function()
                 vim.defer_fn(function()
                     local current_file = vim.fn.expand("%:p")


### PR DESCRIPTION
When using PEP-723 for scripting, the script files are often named without the `.py` suffix to make them more like a regular command. This PR makes the `autocmd` used for auto-activation trigger on the `python` file type to achieve that.

With this change, `venv-selector` works well with the following file named `hello`:

```python
#!/usr/bin/env -S uv run --script
# /// script
# dependencies = [
#   "rich",
# ]
# ///

from rich import print

print("[italic red]Hello[/italic red] World!", locals())

# vim:ft=python
```