### PR TITLE
Fix overwriting client settings on notify for pylsp

### DIFF
--- a/lua/venv-selector/hooks.lua
+++ b/lua/venv-selector/hooks.lua
@@ -168,7 +168,7 @@ function M.configure_lsp_client(client_name, venv_python)
 
         -- Notify client of configuration change (skip for problematic clients)
         if not lsp_config.skip_notify then
-            local notify_settings = lsp_config.use_settings_directly and new_settings or nil
+            local notify_settings = lsp_config.use_settings_directly and client.settings or nil
             client:notify("workspace/didChangeConfiguration", { settings = notify_settings })
         end
 


### PR DESCRIPTION
When pylsp gets settings via didChangeConfiguration it simply replaces the former settings by the given settings. Therefore instead of just giving the changed settings, we provide all the settings which we updated in a previous steps. This prevents the settings from being cleared.

This should be save to do, since pylsp is the only given lsp server which uses the 'use_settings_directly' variable and therefore should be the only lsp affected by this change.

I tested this with 
 - NVIM v0.12.0
 - nvim-lspconfig c8b90ae (current master)
 - python-lsp-server 1.13.1
 - A configuration based in large parts on the kickstart config
