### PR TITLE
feat: picker_options option

### DIFF
--- a/lua/venv-selector/config.lua
+++ b/lua/venv-selector/config.lua
@@ -243,7 +243,12 @@ M.default_settings = {
         picker_icons = {}, -- Override default icons for venv types (e.g., { poetry = "📝", hatch = "🔨", default = "🐍" })
         picker_columns = { "marker", "search_icon", "search_name", "search_result" }, -- Column order in pickers (omit columns to hide them)
         picker = "auto", -- The picker to use. Valid options are "telescope", "fzf-lua", "snacks", "native", "mini-pick" or "auto"
-        statusline_func = { nvchad = nil, lualine = nil }
+        statusline_func = { nvchad = nil, lualine = nil },
+        picker_options = { -- picker-specific options
+            snacks = {
+                layout = { preset = "select" }, -- snacks layout config
+            },
+        },
     },
     search = M.get_default_searches()(),
 }

--- a/lua/venv-selector/gui/snacks.lua
+++ b/lua/venv-selector/gui/snacks.lua
@@ -20,9 +20,7 @@ function M:pick()
         finder = function(opts, ctx)
             return self.results
         end,
-        layout = config.user_settings.options.snacks_layout or {
-            preset = "select",
-        },
+        layout = config.user_settings.options.picker_options.snacks.layout,
         format = function(item, picker)
             local columns = gui_utils.get_picker_columns()
             local hl = gui_utils.hl_active_venv(item)


### PR DESCRIPTION
This option allows users to control the layout of the snacks picker. 

Example usage: https://github.com/joe-p/neovim-config/commit/18cf6f9a432e4416f75228e8d4719ce004ad58f8