### PR TITLE
fix: `picker_columns` for mini-pick

### DIFF
--- a/lua/venv-selector/gui/mini-pick.lua
+++ b/lua/venv-selector/gui/mini-pick.lua
@@ -11,11 +11,23 @@ local function marker_icon()
 end
 
 local function item_to_text(item)
-    local icon = marker_icon()
-    local marker = gui_utils.hl_active_venv(item) and icon or " "
-    local src_icon = gui_utils.draw_icons_for_types(item.source)
-    local src_name = string.format("%-15s", item.source)
-    return table.concat({ marker, src_icon, src_name, item.name }, "  ")
+    local columns = gui_utils.get_picker_columns()
+
+    local column_data = {
+        marker = gui_utils.hl_active_venv(item) and icon or " ",
+        search_icon = gui_utils.draw_icons_for_types(item.source),
+        search_name = string.format("%-15s", item.source),
+        search_result = item.name,
+    }
+
+    local parts = {}
+    for _, col in ipairs(columns) do
+        local v = column_data[col]
+        if v then
+            parts[#parts + 1] = v
+        end
+    end
+    return table.concat(parts, "  ")
 end
 
 -- Character/fuzzy mode (uses MiniPick.default_match + MiniPick.default_show)


### PR DESCRIPTION
Commit 1039c7e19dd28c6b21fdf3edf54b77da80775543 introduced the bug where the `mini-pick` gui doesn't respect the `picker_columns` anymore. I assume this was unintended (other pickers still include this logic).

This PR re-adds the little snippets.