### PR TITLE
fix: add local marker for `mini-pick`

### DIFF
--- a/lua/venv-selector/gui/mini-pick.lua
+++ b/lua/venv-selector/gui/mini-pick.lua
@@ -12,6 +12,7 @@ end
 
 local function item_to_text(item)
     local columns = gui_utils.get_picker_columns()
+    local icon = marker_icon()
 
     local column_data = {
         marker = gui_utils.hl_active_venv(item) and icon or " ",


### PR DESCRIPTION
In 7423056f26a47f7085ce55f44f4ac482fabda5a2 I removed the marker icon by accident. Sorry!