### PR TITLE
fix: split shellcmdflag in search

### DIFF
--- a/lua/venv-selector/search.lua
+++ b/lua/venv-selector/search.lua
@@ -213,12 +213,6 @@ local function start_search_job(search_name, search_config, job_event_handler, s
         return
     end
 
-    local cmd
-    -- Don't expand commands, use them directly
-    local job = search_config.execute_command
-    ---@cast job string
-    local options = require("venv-selector.config").get_user_options()
-
     -- log.debug("Executing search '" ..
     --     search_name .. "' (using " .. options.shell.shell .. " " .. options.shell.shellcmdflag .. "): '" .. job .. "'")
 
@@ -232,24 +226,31 @@ local function start_search_job(search_name, search_config, job_event_handler, s
     -- else
     --     cmd = { options.shell.shell, options.shell.shellcmdflag, job } -- We use a shell on linux and mac but not windows at the moment.
     -- end
+
+    local job = search_config.execute_command
+    ---@cast job string
     local expanded_job = expand_env(job) -- expands $VAR and ~
 
-    log.debug("Executing search '" ..
-        search_name ..
-        "' (using " .. options.shell.shell .. " " .. options.shell.shellcmdflag .. "): '" .. expanded_job .. "'")
-
-    local shell_flags = options.shell.shellcmdflag
-    if type(shell_flags) == "string" then
-        shell_flags = vim.split(shell_flags, " ", { trimempty = true })
+    local options = require("venv-selector.config").get_user_options()
+    local shell = options.shell.shell
+    local shell_cmdflags = options.shell.shellcmdflag
+    if type(shell_cmdflags) == "string" then
+        shell_cmdflags = utils.split_string(shell_cmdflags)
     end
 
-    cmd = { options.shell.shell }
-    if type(shell_flags) == "table" then
-        vim.list_extend(cmd, shell_flags)
-    else
-        table.insert(cmd, shell_flags)
-    end
-    table.insert(cmd, expanded_job)
+    local cmd = utils.extend({ options.shell.shell }, shell_cmdflags, { expanded_job })
+
+    log.debug(
+        "Executing search '"
+            .. search_name
+            .. "' (using "
+            .. shell
+            .. " "
+            .. table.concat(shell_cmdflags, " ")
+            .. "): '"
+            .. expanded_job
+            .. "'"
+    )
 
     local function on_exit_wrapper(jid, data, event)
         -- log.debug(string.format(

--- a/lua/venv-selector/utils.lua
+++ b/lua/venv-selector/utils.lua
@@ -81,6 +81,19 @@ function M.split_cmd_for_windows(str)
     return M.split_string(str)
 end
 
+--- Extend a list with multiple other tables.
+--- Note that the list is modified in place
+--- but also returned for convenience.
+--- @param dst table the list to extend
+--- @param ... table lists of items to extend dst with
+--- @return table the extended list
+function M.extend(dst, ...)
+    for _, t in ipairs({ ... }) do
+        vim.list_extend(dst, t)
+    end
+    return dst
+end
+
 ---Safely access nested table keys
 ---@param tbl table The table to access
 ---@param ... string The keys to follow


### PR DESCRIPTION
the search job execution is broken for shells with multi-argument `shellcmdflag`s (e.g. powershell). The `shellcmdflag` should be split at spaces and inserted as distinct elements into the final command.


context: using `VenvSelect` in powershell causes nonsensical results in the picker list (due to attempted parsing of powershell's error output):

<img width="1555" height="419" alt="image" src="https://github.com/user-attachments/assets/fd3a7ba3-c0cd-4414-be16-49fce7d36262" />
<img width="1478" height="416" alt="image" src="https://github.com/user-attachments/assets/e7dbbb5b-d37c-4167-8245-a540a863302e" />

side note: the optimal solution would be to actually run the `fd` binary directly... especially for powershell as it is very slow to start up.  
Unless the search command is not an executable binary, i currently don't see why going through a shell provides any benefits.  
One reason i can think of is for search to work on windows using builtin tools, where `ls` or `dir` are not binaries, but this can be some conditional behavior when no `fd` or similar is set/detected.