### PR TITLE
docs: remove duplicate ft and keys entries in plugin spec example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,7 @@ Add this to your plugin specs (example):
     { "nvim-telescope/telescope.nvim", version = "*", dependencies = { "nvim-lua/plenary.nvim" } }, -- optional: you can also use fzf-lua, snacks, mini-pick instead.
   },
   ft = "python", -- Load when opening Python files
-  keys = {
-    { ",v", "<cmd>VenvSelect<cr>" }, -- Open picker on keymap
-  },
-  ft = "python",
-  keys = { { ",v", "<cmd>VenvSelect<cr>" } }, -- example keybind
+  keys = { { ",v", "<cmd>VenvSelect<cr>" } }, -- Open picker on keymap
   opts = {
     options = {}, -- plugin-wide options
     search = {}   -- custom search definitions


### PR DESCRIPTION
## Summary

- The lazy.nvim installation example in the README contained `ft` and `keys` defined twice in the same table literal, which is invalid Lua (duplicate table keys — the later value silently shadows the earlier one).
- Removed the redundant first occurrences, keeping a single, clean definition for each key.

## Before

```lua
ft = "python", -- Load when opening Python files
keys = {
  { ",v", "<cmd>VenvSelect<cr>" }, -- Open picker on keymap
},
ft = "python",
keys = { { ",v", "<cmd>VenvSelect<cr>" } }, -- example keybind
```

## After

```lua
ft = "python", -- Load when opening Python files
keys = { { ",v", "<cmd>VenvSelect<cr>" } }, -- Open picker on keymap
```

This PR cost me $0.29.