### PR TITLE
fix: restart late-arriving python LSPs with correct UV venv

### DIFF
--- a/lua/venv-selector/autocmds.lua
+++ b/lua/venv-selector/autocmds.lua
@@ -137,6 +137,44 @@ function M.create()
         end,
     })
 
+    -- ============================================================================
+    -- LspAttach: restart late-arriving python LSPs with correct UV venv
+    -- ============================================================================
+    -- Covers the case where a python LSP (e.g., basedpyright) initializes
+    -- AFTER the UV flow has already resolved the venv python path.
+    -- Uses hook restart (stop+start) instead of didChangeConfiguration
+    -- because basedpyright ignores the advisory notification.
+
+    vim.api.nvim_create_autocmd("LspAttach", {
+        group = uv_group,
+        callback = function(args)
+            local bufnr = args.buf
+            if not is_normal_python_buf(bufnr) then return end
+            if is_disabled(bufnr) then return end
+
+            local uv_python = vim.b[bufnr].venv_selector_uv_last_python
+            if not uv_python or uv_python == "" then return end
+
+            local client = vim.lsp.get_client_by_id(args.data.client_id)
+            if not client then return end
+
+            local hooks = require("venv-selector.hooks")
+            if not hooks.is_python_lsp(client) then return end
+
+            -- Skip clients already managed by the plugin (gate restart sets this flag)
+            if client.config._venv_selector then return end
+
+            local py = ((client.config.settings or {}).python or {}).pythonPath
+            if py == uv_python then return end
+
+            -- Late-arriving python LSP with wrong settings — restart just this client
+            local log = require("venv-selector.logger")
+            log.debug(("LspAttach: restarting %s (pythonPath mismatch)"):format(client.name))
+
+            hooks.restart_single_python_lsp(client, uv_python, "uv", bufnr)
+        end,
+    })
+
     vim.api.nvim_create_autocmd("BufWritePost", {
         group = uv_group,
         callback = function(args)

--- a/lua/venv-selector/hooks.lua
+++ b/lua/venv-selector/hooks.lua
@@ -349,31 +349,40 @@ local function restart_all_python_lsps(venv_python, env_type, bufnr)
         return true
     end
 
-    for gate_key, entry in pairs(by_key) do
-        local old_cfg = entry.client.config or {}
-
-        if old_cfg._venv_selector ~= true then
-            snapshot_original_cfg(gate_key, old_cfg)
-        end
-
-        local cfg = vim.deepcopy(old_cfg)
-        cfg._venv_selector = true
-
-        local gen = default_lsp_settings(entry.name, venv_python, env_type)
-        cfg.settings = gen.settings
-        cfg.cmd_env = gen.cmd_env
-
-        cfg.capabilities = old_cfg.capabilities
-        cfg.handlers = old_cfg.handlers
-        cfg.on_attach = old_cfg.on_attach
-        cfg.init_options = old_cfg.init_options
-
-        cfg._venv_selector = true
-
-        gate.request(gate_key, cfg, entry.bufs)
+    for _, entry in pairs(by_key) do
+        M.restart_single_python_lsp(entry.client, venv_python, env_type, bufnr)
     end
 
     return true
+end
+
+---Restart a single python LSP client with venv-aware settings.
+---Used by restart_all_python_lsps and the LspAttach handler for late arrivals.
+---@param client any
+---@param venv_python string
+---@param env_type venv-selector.VenvType
+---@param bufnr integer
+function M.restart_single_python_lsp(client, venv_python, env_type, bufnr)
+    local gk = gate_key_for_client(client, bufnr)
+    local old_cfg = client.config or {}
+
+    if old_cfg._venv_selector ~= true then
+        snapshot_original_cfg(gk, old_cfg)
+    end
+
+    local cfg = vim.deepcopy(old_cfg)
+    cfg._venv_selector = true
+
+    local gen = default_lsp_settings(client.name, venv_python, env_type)
+    cfg.settings = gen.settings
+    cfg.cmd_env = gen.cmd_env
+
+    cfg.capabilities = old_cfg.capabilities
+    cfg.handlers = old_cfg.handlers
+    cfg.on_attach = old_cfg.on_attach
+    cfg.init_options = old_cfg.init_options
+
+    gate.request(gk, cfg, attached_python_bufs(client))
 end
 
 ---@param venv_python string|nil


### PR DESCRIPTION
Problem: basedpyright starts initialization but is not available as client to update the path after uv python find because it is so slow.

Solution approach: We use autocmds to restart just the late lsp if needed with the correct python path.

Changes:
- Add LspAttach autocmd to catch LSPs (e.g. basedpyright) that initialize after the UV flow resolves the venv python path.
- Extract per-client restart into hooks.restart_single_python_lsp. (hooks.lua)

The hooks.lua diff seems more complex than it is on github web. The patience algorithm for diffing helps. Run from local repo:
```
git fetch origin pull/267/head:pr-267
git diff --diff-algorithm=patience main...pr-267 -- lua/venv-selector/hooks.lua
```