### PR TITLE
feat: user options for telescope picker

### DIFF
--- a/lua/venv-selector/config.lua
+++ b/lua/venv-selector/config.lua
@@ -276,6 +276,7 @@ local default_settings = {
             snacks = {
                 layout = { preset = "select" },
             },
+            telescope = {},
         },
         shell = default_shell_settings(),
     },

--- a/lua/venv-selector/gui/telescope.lua
+++ b/lua/venv-selector/gui/telescope.lua
@@ -113,6 +113,7 @@ end
 ---@return table layout_config
 local function get_dynamic_layout_config()
     local columns = vim.o.columns
+    local opts = config.user_settings.options.picker_options.telescope
 
     local width_ratio = 0.9
     local min_width = 60
@@ -124,11 +125,11 @@ local function get_dynamic_layout_config()
     local max_height = 0.6
     local dynamic_height = math.max(min_height, math.min(max_height, height_ratio))
 
-    return {
+    return vim.tbl_deep_extend("force", {
         height = dynamic_height,
         width = dynamic_width,
         prompt_position = "top",
-    }
+    }, opts.layout_config or {})
 end
 
 ---@return table display_config
@@ -301,7 +302,7 @@ function M.new(search_opts)
     local marker_color = config.user_settings.options.selected_venv_marker_color
     vim.api.nvim_set_hl(0, "VenvSelectMarker", { fg = marker_color })
 
-    local opts = {
+    local opts = vim.tbl_deep_extend("force", {
         prompt_title = "Virtual environments (ctrl-r to refresh)",
         finder = self:make_finder(),
         layout_strategy = "vertical",
@@ -331,7 +332,7 @@ function M.new(search_opts)
 
             return true
         end,
-    }
+   }, config.user_settings.options.picker_options.telescope)
 
     local picker = require("telescope.pickers").new({}, opts)
 

--- a/lua/venv-selector/types.lua
+++ b/lua/venv-selector/types.lua
@@ -109,6 +109,7 @@ local M = {}
 
 ---@class venv-selector.PickerOptions
 ---@field snacks? table Snacks picker specific options
+---@field telescope? table Telescope picker specific options
 
 ---@class venv-selector.Options
 ---@field on_venv_activate_callback? fun()


### PR DESCRIPTION
Added Telescope options similarly to `picker_options.snacks`. This way user can customize default Telescope picker with the view they prefer. For example, I'm doing bottom prompt position like so:

```lua
options = {
  picker = "telescope",
  picker_options = {
    telescope = {
      sorting_strategy = "descending",
      layout_config = {
        prompt_position = "bottom",
      },
    },
  },
},
```