### PR TITLE
fix(deactivate): run PATH/env cleanup before clearing active state

### DIFF
--- a/lua/venv-selector/init.lua
+++ b/lua/venv-selector/init.lua
@@ -118,15 +118,18 @@ function M.deactivate()
     -- Clear restart memo so selecting the same venv again forces restart.
     hooks.clear_restart_memo_for_root(project_root)
 
-    -- 2) Clear plugin active state so re-activation is not skipped.
-    require("venv-selector.venv").clear_active_state(bufnr)
-
-    -- 3) Restore baseline python LSP configs.
-    hooks.restore_original_python_lsps_for_buf(bufnr, stopped_keys)
-
-    -- 4) PATH/env cleanup.
+    -- 2) PATH/env cleanup. Must run before clear_active_state() below, since
+    -- path.remove_current() only acts `if M.current_python_path then` -- once
+    -- that's nil'd out, it silently no-ops and the venv's bin dir is never
+    -- actually removed from $PATH.
     require("venv-selector.path").remove_current()
     require("venv-selector.venv").unset_env_variables()
+
+    -- 3) Clear plugin active state so re-activation is not skipped.
+    require("venv-selector.venv").clear_active_state(bufnr)
+
+    -- 4) Restore baseline python LSP configs.
+    hooks.restore_original_python_lsps_for_buf(bufnr, stopped_keys)
 end
 
 local function setup_notify()


### PR DESCRIPTION
## Summary
`deactivate()` calls `path.remove_current()` *after* `venv.clear_active_state()` has already set `path.current_python_path = nil`. Since `remove_current()` only acts `if M.current_python_path then`, it silently no-ops — the venv's `bin/` directory is never actually stripped from `$PATH`.

The LSP client itself does get correctly stopped and restarted with a clean baseline config (no `pythonPath`/venv `settings`), but the freshly spawned server process still inherits the stale `$PATH`, so it keeps resolving imports and `textDocument/definition` into the deactivated venv's `site-packages` — even though the client's reported config looks completely clean. This makes it look like a config/LSP-restart problem when it's actually just the `$PATH` string never being touched.

## Fix
Reorder `deactivate()` so PATH/env cleanup runs while `current_python_path` is still set, before `clear_active_state()` nils it out. The LSP stop/restore steps are otherwise unchanged.

## Test plan
- [ ] Activate a venv with `:VenvSelect`, confirm LSP resolves imports from it
- [ ] `deactivate()`, confirm `$PATH` no longer contains the venv's `bin/` dir (`echo $PATH` in a `:terminal`, or check `vim.env.PATH`)
- [ ] Confirm go-to-definition and diagnostics on an import from a package installed only inside the venv (not available system-wide) now correctly fail/show unresolved, instead of still resolving into the deactivated venv